### PR TITLE
Remove lazy join from ipallocationpools

### DIFF
--- a/patches/remove_lazy_join_from_ipallocationpools.patch
+++ b/patches/remove_lazy_join_from_ipallocationpools.patch
@@ -1,0 +1,12 @@
+diff --git a/neutron/db/models_v2.py b/neutron/db/models_v2.py
+index a2f1e03..ba7fcf3 100644
+--- a/neutron/db/models_v2.py
++++ b/neutron/db/models_v2.py
+@@ -80,7 +80,6 @@ class IPAllocationPool(model_base.BASEV2, HasId):
+     last_ip = sa.Column(sa.String(64), nullable=False)
+     available_ranges = orm.relationship(IPAvailabilityRange,
+                                         backref='ipallocationpool',
+-                                        lazy="joined",
+                                         cascade='delete')
+
+     def __repr__(self):

--- a/patches/utils
+++ b/patches/utils
@@ -8,7 +8,7 @@ function patch_neutron() {
     # has been proposed for juno but not merged yet.
     cd $DEST/neutron
     LAST_COMMIT_HASH="$(git diff HEAD^ | md5sum | awk '{ print $1 }')"
-    PATCH_HASH="$(cat $PATCHES_FOLDER/fix_neutron_to_nova_notification.patch | md5sum | awk '{ print $1 }')"
+    PATCH_HASH="$(cat $PATCHES_FOLDER/remove_lazy_join_from_ipallocationpools.patch | md5sum | awk '{ print $1 }')"
     # Apply the patch just first time we stack
     if [ "$LAST_COMMIT_HASH" != "$PATCH_HASH" ]; then
         git fetch https://review.openstack.org/openstack/neutron refs/changes/48/17248/4 && git cherry-pick FETCH_HEAD || true
@@ -38,5 +38,12 @@ function patch_neutron() {
         git apply $PATCHES_FOLDER/fix_neutron_to_nova_notification.patch
         git add .
         git commit -m "DreamHost: Fix neutron-to-nova notification about ports creation"
+
+        # The combiniation of slack addresses for ipv6 and poor handling of ipv6 ipavailabilityranges
+        # in neutron makes many calls to neutron's API(like net-list) extremely slow.
+        # To fix this we need to remove the lazy join from the IPAllocationPool model.
+        git apply $PATCHES_FOLDER/remove_lazy_join_from_ipallocationpools.patch
+        git add .
+        git commit -m "DreamHost: Remove lazy join from ipallocationpools"
     fi
 }


### PR DESCRIPTION
The combiniation of slack addresses for ipv6 and poor handling
of ipv6 ipavailabilityranges in neutron makes many calls to
neutron's API(like net-list) extremely slow.
To fix this we need to remove the lazy join from the
IPAllocationPool model.

Change-Id: I124ff2c7becf92cfaecbd26d866d2bbdac465408
Signed-off-by: Rosario Di Somma rosario.disomma@dreamhost.com
