### PR TITLE
Run patch_neutron function from the correct dir

### DIFF
--- a/20-akanda.sh
+++ b/20-akanda.sh
@@ -15,11 +15,14 @@ elif [[ "$1" == "stack" && "$2" == "install" ]]; then
 
 elif [[ "$1" == "stack" && "$2" == "post-config" ]]; then
     echo_summary "Patching Neutron"
+    old_cwd=$PWD
+    cd $DEST/neutron
     patch_neutron
     echo_summary "Installing Akanda"
     configure_akanda
     configure_akanda_nova
     configure_akanda_neutron
+    cd $old_cwd
 
 elif [[ "$1" == "stack" && "$2" == "extra" ]]; then
     echo_summary "Initializing Akanda"

--- a/patches/utils
+++ b/patches/utils
@@ -6,7 +6,6 @@
 function patch_neutron() {
     # The RUG doesn't work with vanilla icehouse neutron, to make it works we need to backport a patch that
     # has been proposed for juno but not merged yet.
-    cd $DEST/neutron
     LAST_COMMIT_HASH="$(git diff HEAD^ | md5sum | awk '{ print $1 }')"
     PATCH_HASH="$(cat $PATCHES_FOLDER/remove_lazy_join_from_ipallocationpools.patch | md5sum | awk '{ print $1 }')"
     # Apply the patch just first time we stack


### PR DESCRIPTION
The patch_neutron function is used in a few places and makes some
assumptions about the current working directory. These assumptions are
breaking other uses of patch_neutron (namely, Jenkins packaging job).
This patch removes the "cd" in the function and moves it into
20-akanda.sh, thus addressing pathing without having to modify anything
else (namely, Jenkins packaging jobs).
