### PR TITLE
Allow function patch_neutron to accept a directory

### DIFF
--- a/patches/utils
+++ b/patches/utils
@@ -4,9 +4,21 @@
 # neutron and make it work with akanda.
 
 function patch_neutron() {
+    # If we need to change directories to apply the patch, this should be specified by calling the funciton
+    # and passing the directory to cd to. For example:
+    # patch_neutron /var/tmp/
+    # This will assume that from /var/tmp, the following patches will be able to found the files to patch.
+    if [[ "$1" != "" ]]; then
+        if [[ -d "$1" ]]; then
+	    cd  $1
+	else
+	    echo "$0 called with invalid directory: $1 does not exist"
+	fi
+    else
+        cd $DEST/neutron
+    fi
     # The RUG doesn't work with vanilla icehouse neutron, to make it works we need to backport a patch that
     # has been proposed for juno but not merged yet.
-    cd $DEST/neutron
     LAST_COMMIT_HASH="$(git diff HEAD^ | md5sum | awk '{ print $1 }')"
     PATCH_HASH="$(cat $PATCHES_FOLDER/remove_lazy_join_from_ipallocationpools.patch | md5sum | awk '{ print $1 }')"
     # Apply the patch just first time we stack


### PR DESCRIPTION
The patch_neutron function is used in a few places and makes some
assumptions about the current working directory. These assumptions are
breaking other uses of patch_neutron (namely, Jenkins packaging job).
This patch allows the patch_neutron function to be called with a
parameter, thus allowing a default action (of "cd $DEST/neutron") or
allowing the user to override the default (by calling the function by:
patch_neutron /var/tmp).

This may (will) required additional changes to anything using this function
that needs to call the function differently (namely, Jenkins packaging jobs).
