### PR TITLE
Add our (massive) L3 router port relationship patch so we can track it.

### DIFF
--- a/patches/l3-router-port-relationship.patch
+++ b/patches/l3-router-port-relationship.patch
@@ -1,0 +1,3186 @@
+From ae6e7e5d52fab4e023b3f94fdba09f16d982bb4f Mon Sep 17 00:00:00 2001
+From: Mark McClain <mark.mcclain@dreamhost.com>
+Date: Tue, 2 Oct 2012 12:36:18 -0400
+Subject: [PATCH] add routerport instead of overloading device_id
+
+implements blueprint l3-router-port-relationship
+
+Previously the l3_agent relied on overloading the device_id attribute to
+link a port to a router. Overloading this attribute prevents using the
+L3 extension in situations where the router might be a service VM (Nova
+will not use a port that already has a device_id).
+
+Change-Id: I23a3a45665db8f61ce94f624f52a019b89e51570
+---
+ neutron/agent/l3_agent.py               |   24 +-
+ neutron/db/db_base_plugin_v2.py         |   17 +-
+ neutron/db/extraroute_db.py             |    5 +-
+ neutron/db/l3_db.py                     |  534 ++++----
+ neutron/db/models_v2.py                 |    4 +
+ neutron/extensions/l3.py                |    4 +-
+ neutron/plugins/nicira/NeutronPlugin.py | 2059 +++++++++++++++++++++++++++++++
+ neutron/tests/unit/test_l3_agent.py     |    4 +-
+ neutron/tests/unit/test_l3_plugin.py    |  102 +-
+ 9 files changed, 2438 insertions(+), 315 deletions(-)
+ create mode 100644 neutron/plugins/nicira/NeutronPlugin.py
+
+diff --git a/neutron/agent/l3_agent.py b/neutron/agent/l3_agent.py
+index 8ddbd75..5b634f1 100644
+--- a/neutron/agent/l3_agent.py
++++ b/neutron/agent/l3_agent.py
+@@ -405,7 +405,12 @@ class L3NATAgent(firewall_l3_agent.FWaaSL3AgentRpcCallback, manager.Manager):
+         if len(ips) > 1:
+             LOG.error(_("Ignoring multiple IPs on router port %s"),
+                       port['id'])
+-        prefixlen = netaddr.IPNetwork(port['subnet']['cidr']).prefixlen
++
++        # handle transition from Grizzly to Havana+
++        if 'subnet' in port:  # Grizzly
++            prefixlen = netaddr.IPNetwork(port['subnet']['cidr']).prefixlen
++        else:  # Havana+
++            prefixlen = netaddr.IPNetwork(ips[0]['subnet']['cidr']).prefixlen
+         port['ip_cidr'] = "%s/%s" % (ips[0]['ip_address'], prefixlen)
+ 
+     def _get_existing_devices(self, ri):
+@@ -418,12 +423,11 @@ class L3NATAgent(firewall_l3_agent.FWaaSL3AgentRpcCallback, manager.Manager):
+         ri.iptables_manager.defer_apply_on()
+         ex_gw_port = self._get_ex_gw_port(ri)
+         internal_ports = ri.router.get(l3_constants.INTERFACE_KEY, [])
+-        existing_port_ids = set([p['id'] for p in ri.internal_ports])
+-        current_port_ids = set([p['id'] for p in internal_ports
+-                                if p['admin_state_up']])
++        existing_port_ids = set(p['id'] for p in ri.internal_ports)
++        current_port_ids = set(p['id'] for p in internal_ports
++                               if p['admin_state_up'])
+         new_ports = [p for p in internal_ports if
+-                     p['id'] in current_port_ids and
+-                     p['id'] not in existing_port_ids]
++                     p['id'] in (current_port_ids - existing_port_ids)]
+         old_ports = [p for p in ri.internal_ports if
+                      p['id'] not in current_port_ids]
+         for p in new_ports:
+@@ -649,8 +653,12 @@ class L3NATAgent(firewall_l3_agent.FWaaSL3AgentRpcCallback, manager.Manager):
+         ip_address = ex_gw_port['ip_cidr'].split('/')[0]
+         self._send_gratuitous_arp_packet(ri, interface_name, ip_address)
+ 
+-        gw_ip = ex_gw_port['subnet']['gateway_ip']
+-        if ex_gw_port['subnet']['gateway_ip']:
++        # handle transition from Grizzly to Havana+
++        if 'subnet' in ex_gw_port:  # Grizzly
++            gw_ip = ex_gw_port['subnet']['gateway_ip']
++        else:  # Havana+
++            gw_ip = ex_gw_port['fixed_ips'][0]['subnet']['gateway_ip']
++        if gw_ip:
+             cmd = ['route', 'add', 'default', 'gw', gw_ip]
+             ip_wrapper = ip_lib.IPWrapper(self.root_helper,
+                                           namespace=ri.ns_name)
+diff --git a/neutron/db/db_base_plugin_v2.py b/neutron/db/db_base_plugin_v2.py
+index 59ace79..3eaa346 100644
+--- a/neutron/db/db_base_plugin_v2.py
++++ b/neutron/db/db_base_plugin_v2.py
+@@ -915,8 +915,8 @@ class NeutronDbPluginV2(neutron_plugin_base_v2.NeutronPluginBaseV2,
+                }
+         return self._fields(res, fields)
+ 
+-    def _make_port_dict(self, port, fields=None,
+-                        process_extensions=True):
++    def _make_port_dict(self, port, fields=None, process_extensions=True,
++                        depth=0):
+         res = {"id": port["id"],
+                'name': port['name'],
+                "network_id": port["network_id"],
+@@ -924,15 +924,22 @@ class NeutronDbPluginV2(neutron_plugin_base_v2.NeutronPluginBaseV2,
+                "mac_address": port["mac_address"],
+                "admin_state_up": port["admin_state_up"],
+                "status": port["status"],
+-               "fixed_ips": [{'subnet_id': ip["subnet_id"],
+-                              'ip_address': ip["ip_address"]}
+-                             for ip in port["fixed_ips"]],
+                "device_id": port["device_id"],
+                "device_owner": port["device_owner"]}
+         # Call auxiliary extend functions, if any
+         if process_extensions:
+             self._apply_dict_extend_functions(
+                 attributes.PORTS, res, port)
++
++        if depth >= 1:
++            res['fixed_ips'] = [{'subnet_id': ip["subnet_id"],
++                                'ip_address': ip["ip_address"],
++                                'subnet': self._make_subnet_dict(ip.subnet)}
++                                for ip in port["fixed_ips"]]
++        else:
++            res['fixed_ips'] = [{'subnet_id': ip["subnet_id"],
++                                'ip_address': ip["ip_address"]}
++                                for ip in port["fixed_ips"]]
+         return self._fields(res, fields)
+ 
+     def _create_bulk(self, resource, context, request_items):
+diff --git a/neutron/db/extraroute_db.py b/neutron/db/extraroute_db.py
+index dc8fb77..c2e14c1 100644
+--- a/neutron/db/extraroute_db.py
++++ b/neutron/db/extraroute_db.py
+@@ -102,8 +102,7 @@ class ExtraRoute_db_mixin(l3_db.L3_NAT_db_mixin):
+                         routes=routes,
+                         reason=_('the nexthop is used by router'))
+ 
+-    def _validate_routes(self, context,
+-                         router_id, routes):
++    def _validate_routes(self, context, router, routes):
+         if len(routes) > cfg.CONF.max_routes:
+             raise extraroute.RoutesExhausted(
+                 router_id=router_id,
+@@ -113,7 +112,7 @@ class ExtraRoute_db_mixin(l3_db.L3_NAT_db_mixin):
+         ports = self._core_plugin.get_ports(context, filters)
+         for route in routes:
+             self._validate_routes_nexthop(
+-                context, ports, routes, route['nexthop'])
++                context, router.ports, routes, route['nexthop'])
+ 
+     def _update_extra_routes(self, context, router, routes):
+         self._validate_routes(context, router['id'],
+diff --git a/neutron/db/l3_db.py b/neutron/db/l3_db.py
+index 626e19b..51d03e1 100644
+--- a/neutron/db/l3_db.py
++++ b/neutron/db/l3_db.py
+@@ -46,14 +46,34 @@ EXTERNAL_GW_INFO = l3.EXTERNAL_GW_INFO
+ API_TO_DB_COLUMN_MAP = {'port_id': 'fixed_port_id'}
+ 
+ 
++class RouterPort(model_base.BASEV2, models_v2.HasId):
++    router_id = sa.Column(
++        sa.String(36),
++        sa.ForeignKey('routers.id', ondelete="CASCADE"),
++        primary_key=True)
++    port_id = sa.Column(
++        sa.String(36),
++        sa.ForeignKey('ports.id', ondelete="CASCADE"),
++        primary_key=True)
++    port_type = sa.Column(sa.String(255), nullable=False)
++    port = orm.relationship(
++        models_v2.Port,
++        backref=orm.backref('routerport', uselist=False, cascade="all,delete"))
++
++
+ class Router(model_base.BASEV2, models_v2.HasId, models_v2.HasTenant):
+     """Represents a v2 neutron router."""
+ 
+     name = sa.Column(sa.String(255))
+     status = sa.Column(sa.String(16))
+     admin_state_up = sa.Column(sa.Boolean)
+-    gw_port_id = sa.Column(sa.String(36), sa.ForeignKey('ports.id'))
++    gw_port_id = sa.Column(
++        sa.String(36),
++        sa.ForeignKey('ports.id'))
+     gw_port = orm.relationship(models_v2.Port, lazy='joined')
++    attached_ports = orm.relationship(
++        RouterPort,
++        backref='router', lazy='dynamic')
+ 
+ 
+ class FloatingIP(model_base.BASEV2, models_v2.HasId, models_v2.HasTenant):
+@@ -75,6 +95,7 @@ class FloatingIP(model_base.BASEV2, models_v2.HasId, models_v2.HasTenant):
+     # aysnchronous backend is unavailable when the floating IP is disassociated
+     last_known_router_id = sa.Column(sa.String(36))
+     status = sa.Column(sa.String(16))
++    router = orm.relationship(Router, backref='floating_ips')
+ 
+ 
+ class L3_NAT_db_mixin(l3.RouterPluginBase):
+@@ -93,8 +114,8 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+             raise l3.RouterNotFound(router_id=id)
+         return router
+ 
+-    def _make_router_dict(self, router, fields=None,
+-                          process_extensions=True):
++    def _make_router_dict(self, router, fields=None, process_extensions=True,
++                          depth=0):
+         res = {'id': router['id'],
+                'name': router['name'],
+                'tenant_id': router['tenant_id'],
+@@ -102,6 +123,7 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                'status': router['status'],
+                EXTERNAL_GW_INFO: None,
+                'gw_port_id': router['gw_port_id']}
++
+         if router['gw_port_id']:
+             nw_id = router.gw_port['network_id']
+             res[EXTERNAL_GW_INFO] = {'network_id': nw_id}
+@@ -111,16 +133,40 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+         if process_extensions:
+             self._apply_dict_extend_functions(
+                 l3.ROUTERS, res, router)
++
++        if depth:
++            if router.gw_port:
++                res['gw_port'] = self._core_plugin._make_port_dict(
++                    router.gw_port,
++                    depth=(depth - 1))
++            else:
++                res['gw_port'] = None
++
++            # include all ports associated with router as this change allows
++            # for custom plugin port types
++            res['ports'] = [
++                self._core_plugin._make_port_dict(rp.port, depth=(depth - 1))
++                for rp in router['attached_ports']
++            ]
++
++            # compat for grizzly style
++            res[l3_constants.INTERFACE_KEY] = [
++                p for p in res['ports']
++                if p['device_owner'] == DEVICE_OWNER_ROUTER_INTF
++            ]
++
++            res[l3_constants.FLOATINGIP_KEY] = [
++                self._make_floatingip_dict(floatingip)
++                for floatingip in router.floating_ips
++            ]
++
+         return self._fields(res, fields)
+ 
+     def create_router(self, context, router):
+         r = router['router']
+-        has_gw_info = False
+-        if EXTERNAL_GW_INFO in r:
+-            has_gw_info = True
+-            gw_info = r[EXTERNAL_GW_INFO]
+-            del r[EXTERNAL_GW_INFO]
++        gw_info = r.pop(EXTERNAL_GW_INFO, None)
+         tenant_id = self._get_tenant_id_for_create(context, r)
++
+         with context.session.begin(subtransactions=True):
+             # pre-generate id so it will be available when
+             # configuring external gw port
+@@ -130,30 +176,18 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                                admin_state_up=r['admin_state_up'],
+                                status="ACTIVE")
+             context.session.add(router_db)
+-            if has_gw_info:
+-                self._update_router_gw_info(context, router_db['id'], gw_info)
++            if gw_info:
++                self._update_router_gw_info(context, router_db, gw_info)
+         return self._make_router_dict(router_db, process_extensions=False)
+ 
+     def update_router(self, context, id, router):
+         r = router['router']
+-        has_gw_info = False
+-        gw_info = None
+-        if EXTERNAL_GW_INFO in r:
+-            has_gw_info = True
+-            gw_info = r[EXTERNAL_GW_INFO]
+-            del r[EXTERNAL_GW_INFO]
+-        # check whether router needs and can be rescheduled to the proper
+-        # l3 agent (associated with given external network);
+-        # do check before update in DB as an exception will be raised
+-        # in case no proper l3 agent found
+-        candidates = None
+-        if has_gw_info:
+-            candidates = self._check_router_needs_rescheduling(
+-                context, id, gw_info)
++        has_gw_info = EXTERNAL_GW_INFO in r
++        gw_info = r.pop(EXTERNAL_GW_INFO, None)
+         with context.session.begin(subtransactions=True):
+-            if has_gw_info:
+-                self._update_router_gw_info(context, id, gw_info)
+             router_db = self._get_router(context, id)
++            if gw_info is not None:
++                self._update_router_gw_info(context, router_db, gw_info)
+             # Ensure we actually have something to update
+             if r.keys():
+                 router_db.update(r)
+@@ -237,7 +271,7 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                      'network_id': network_id,
+                      'mac_address': attributes.ATTR_NOT_SPECIFIED,
+                      'fixed_ips': attributes.ATTR_NOT_SPECIFIED,
+-                     'device_id': router['id'],
++                     'device_id': '',  # formerly router['id'],
+                      'device_owner': DEVICE_OWNER_ROUTER_GW,
+                      'admin_state_up': True,
+                      'name': ''}})
+@@ -252,16 +286,20 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+         with context.session.begin(subtransactions=True):
+             router.gw_port = self._core_plugin._get_port(context.elevated(),
+                                                          gw_port['id'])
++            rp = RouterPort(router_id=router.id,
++                            port_id=gw_port['id'],
++                            port_type=DEVICE_OWNER_ROUTER_GW)
++            router.gw_port_id = gw_port['id']
+             context.session.add(router)
++            context.session.add(rp)
+ 
+-    def _update_router_gw_info(self, context, router_id, info, router=None):
++    def _update_router_gw_info(self, context, router, info):
+         # TODO(salvatore-orlando): guarantee atomic behavior also across
+         # operations that span beyond the model classes handled by this
+         # class (e.g.: delete_port)
+-        router = router or self._get_router(context, router_id)
+         gw_port = router.gw_port
+         # network_id attribute is required by API, so it must be present
+-        network_id = info['network_id'] if info else None
++        network_id = info.get('network_id') if info else None
+         if network_id:
+             network_db = self._core_plugin._get_network(context, network_id)
+             if not network_db.external:
+@@ -271,26 +309,30 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+ 
+         # figure out if we need to delete existing port
+         if gw_port and gw_port['network_id'] != network_id:
+-            fip_count = self.get_floatingips_count(context.elevated(),
+-                                                   {'router_id': [router_id]})
++            fip_count = self.get_floatingips_count(
++                context.elevated(),
++                {'router_id': [router.id]}
++            )
+             if fip_count:
+                 raise l3.RouterExternalGatewayInUseByFloatingIp(
+-                    router_id=router_id, net_id=gw_port['network_id'])
++                    router_id=router.id, net_id=gw_port['network_id'])
+             with context.session.begin(subtransactions=True):
+                 router.gw_port = None
+                 context.session.add(router)
+-            self._core_plugin.delete_port(context.elevated(),
+-                                          gw_port['id'],
+-                                          l3_port_check=False)
++                context.session.expire(gw_port)
++            self._core_plugin.delete_port(
++                context.elevated(),
++                gw_port['id'],
++                l3_port_check=False)
++            gw_port = None
+ 
+         if network_id is not None and (gw_port is None or
+                                        gw_port['network_id'] != network_id):
+             subnets = self._core_plugin._get_subnets_by_network(context,
+                                                                 network_id)
+             for subnet in subnets:
+-                self._check_for_dup_router_subnet(context, router_id,
+-                                                  network_id, subnet['id'],
+-                                                  subnet['cidr'])
++                self._check_for_dup_router_subnet(context, router,
++                                                  network_id, subnet)
+             self._create_router_gw_port(context, router, network_id)
+ 
+     def delete_router(self, context, id):
+@@ -303,11 +345,8 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+             if fips:
+                 raise l3.RouterInUse(router_id=id)
+ 
+-            device_filter = {'device_id': [id],
+-                             'device_owner': [DEVICE_OWNER_ROUTER_INTF]}
+-            ports = self._core_plugin.get_ports_count(context.elevated(),
+-                                                      filters=device_filter)
+-            if ports:
++            if any(rp.port_type == DEVICE_OWNER_ROUTER_INTF
++                   for rp in router.attached_ports.all()):
+                 raise l3.RouterInUse(router_id=id)
+ 
+             #TODO(nati) Refactor here when we have router insertion model
+@@ -316,23 +355,18 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+             if vpnservice:
+                 vpnservice.check_router_in_use(context, id)
+ 
++            # delete any gw port
++            for rp in router.attached_ports.all():
++                self._core_plugin.delete_port(
++                    context.elevated(),
++                    rp.port['id'],
++                    l3_port_check=False)
+             context.session.delete(router)
+-
+-            # Delete the gw port after the router has been removed to
+-            # avoid a constraint violation.
+-            device_filter = {'device_id': [id],
+-                             'device_owner': [DEVICE_OWNER_ROUTER_GW]}
+-            ports = self._core_plugin.get_ports(context.elevated(),
+-                                                filters=device_filter)
+-            if ports:
+-                self._core_plugin._delete_port(context.elevated(),
+-                                               ports[0]['id'])
+-
+         self.l3_rpc_notifier.router_deleted(context, id)
+ 
+     def get_router(self, context, id, fields=None):
+         router = self._get_router(context, id)
+-        return self._make_router_dict(router, fields)
++        return self._make_router_dict(router, fields, depth=1)
+ 
+     def get_routers(self, context, filters=None, fields=None,
+                     sorts=None, limit=None, marker=None,
+@@ -350,29 +384,28 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+         return self._get_collection_count(context, Router,
+                                           filters=filters)
+ 
+-    def _check_for_dup_router_subnet(self, context, router_id,
+-                                     network_id, subnet_id, subnet_cidr):
++    def _check_for_dup_router_subnet(self, context, router,
++                                     network_id, subnet):
+         try:
+-            rport_qry = context.session.query(models_v2.Port)
+-            rports = rport_qry.filter_by(device_id=router_id)
+-            # It's possible these ports are on the same network, but
+-            # different subnets.
+-            new_ipnet = netaddr.IPNetwork(subnet_cidr)
+-            for p in rports:
++            new_ipnet = netaddr.IPNetwork(subnet['cidr'])
++            for p in [rp.port for rp in router.attached_ports]:
+                 for ip in p['fixed_ips']:
+-                    if ip['subnet_id'] == subnet_id:
++                    if ip['subnet_id'] == subnet['id']:
+                         msg = (_("Router already has a port on subnet %s")
+-                               % subnet_id)
++                               % subnet['id'])
+                         raise n_exc.BadRequest(resource='router', msg=msg)
+                     sub_id = ip['subnet_id']
+                     cidr = self._core_plugin._get_subnet(context.elevated(),
+                                                          sub_id)['cidr']
+                     ipnet = netaddr.IPNetwork(cidr)
+                     match1 = netaddr.all_matching_cidrs(new_ipnet, [cidr])
+-                    match2 = netaddr.all_matching_cidrs(ipnet, [subnet_cidr])
++                    match2 = netaddr.all_matching_cidrs(
++                        ipnet,
++                        [subnet['cidr']]
++                    )
+                     if match1 or match2:
+-                        data = {'subnet_cidr': subnet_cidr,
+-                                'subnet_id': subnet_id,
++                        data = {'subnet_cidr': subnet.cidr,
++                                'subnet_id': subnet.id,
+                                 'cidr': cidr,
+                                 'sub_id': sub_id}
+                         msg = (_("Cidr %(subnet_cidr)s of subnet "
+@@ -387,6 +420,11 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+             msg = _("Either subnet_id or port_id must be specified")
+             raise n_exc.BadRequest(resource='router', msg=msg)
+ 
++        # make sure router exists
++        new_to_router = True
++        router = self._get_router(context, router_id)
++        device_owner = interface_info.get('owner', DEVICE_OWNER_ROUTER_INTF)
++
+         if 'port_id' in interface_info:
+             # make sure port update is committed
+             with context.session.begin(subtransactions=True):
+@@ -394,54 +432,89 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                     msg = _("Cannot specify both subnet-id and port-id")
+                     raise n_exc.BadRequest(resource='router', msg=msg)
+ 
+-                port = self._core_plugin._get_port(context,
+-                                                   interface_info['port_id'])
+-                if port['device_id']:
++                port = self._core_plugin._get_port(
++                    context,
++                    interface_info['port_id'])
++
++                if port['device_id'] or port['routerport']:
+                     raise n_exc.PortInUse(net_id=port['network_id'],
+                                           port_id=port['id'],
+                                           device_id=port['device_id'])
+                 fixed_ips = [ip for ip in port['fixed_ips']]
+-                if len(fixed_ips) != 1:
+-                    msg = _('Router port must have exactly one fixed IP')
+-                    raise n_exc.BadRequest(resource='router', msg=msg)
+-                subnet_id = fixed_ips[0]['subnet_id']
+-                subnet = self._core_plugin._get_subnet(context, subnet_id)
+-                self._check_for_dup_router_subnet(context, router_id,
++                subnet = self._core_plugin._get_subnet(
++                    context,
++                    fixed_ips[0]['subnet_id'])
++                self._check_for_dup_router_subnet(context, router,
+                                                   port['network_id'],
+-                                                  subnet['id'],
+-                                                  subnet['cidr'])
+-                port.update({'device_id': router_id,
+-                             'device_owner': DEVICE_OWNER_ROUTER_INTF})
++                                                  subnet)
++                port['device_owner'] = device_owner
+         elif 'subnet_id' in interface_info:
+-            subnet_id = interface_info['subnet_id']
+-            subnet = self._core_plugin._get_subnet(context, subnet_id)
++            subnet = self._core_plugin._get_subnet(
++                context,
++                interface_info['subnet_id'])
++
+             # Ensure the subnet has a gateway
+             if not subnet['gateway_ip']:
+                 msg = _('Subnet for router interface must have a gateway IP')
+                 raise n_exc.BadRequest(resource='router', msg=msg)
+-            self._check_for_dup_router_subnet(context, router_id,
++            self._check_for_dup_router_subnet(context, router,
+                                               subnet['network_id'],
+-                                              subnet_id,
+-                                              subnet['cidr'])
++                                              subnet)
+             fixed_ip = {'ip_address': subnet['gateway_ip'],
+                         'subnet_id': subnet['id']}
+-            port = self._core_plugin.create_port(context, {
+-                'port':
+-                {'tenant_id': subnet['tenant_id'],
+-                 'network_id': subnet['network_id'],
+-                 'fixed_ips': [fixed_ip],
+-                 'mac_address': attributes.ATTR_NOT_SPECIFIED,
+-                 'admin_state_up': True,
+-                 'device_id': router_id,
+-                 'device_owner': DEVICE_OWNER_ROUTER_INTF,
+-                 'name': ''}})
++
++            # check if network is already attached to the router
++            for rp in router.attached_ports:
++                if rp.port.network_id == subnet.network_id:
++                    fixed_ips = [
++                        {
++                            'subnet_id': ip['subnet_id'],
++                            'ip_address': ip['ip_address']
++                        }
++                        for ip in rp.port["fixed_ips"]
++                    ]
++                    fixed_ips.append(fixed_ip)
++                    port = self._core_plugin.update_port(
++                        context,
++                        rp.port_id,
++                        {'port': {'fixed_ips': fixed_ips}}
++                    )
++                    new_to_router = False
++                    break
++            else:
++                port = self._core_plugin.create_port(context, {
++                    'port':
++                    {'tenant_id': subnet['tenant_id'],
++                     'network_id': subnet['network_id'],
++                     'fixed_ips': [fixed_ip],
++                     'mac_address': attributes.ATTR_NOT_SPECIFIED,
++                     'admin_state_up': True,
++                     'device_id': '',
++                     'device_owner': device_owner,
++                     'name': ''}})
++
++        with context.session.begin(subtransactions=True):
++            if new_to_router:
++                rp = RouterPort(
++                    port_id=port['id'],
++                    router_id=router['id'],
++                    port_type=device_owner
++                )
++                context.session.add(rp)
+ 
+         self.l3_rpc_notifier.routers_updated(
+             context, [router_id], 'add_router_interface')
+-        info = {'id': router_id,
+-                'tenant_id': subnet['tenant_id'],
+-                'port_id': port['id'],
+-                'subnet_id': port['fixed_ips'][0]['subnet_id']}
++
++        info = {
++            'id': router_id,
++            'tenant_id': subnet['tenant_id'],
++            'port_id': port['id'],
++            'subnet_id': interface_info.get(
++                'subnet_id',
++                port['fixed_ips'][0]['subnet_id']
++            )
++        }
++
+         notifier_api.notify(context,
+                             notifier_api.publisher_id('network'),
+                             'router.interface.create',
+@@ -460,16 +533,22 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                     router_id=router_id, subnet_id=subnet_id)
+ 
+     def remove_router_interface(self, context, router_id, interface_info):
++        router = self._get_router(context, router_id)
+         if not interface_info:
+             msg = _("Either subnet_id or port_id must be specified")
+             raise n_exc.BadRequest(resource='router', msg=msg)
+         if 'port_id' in interface_info:
+             port_id = interface_info['port_id']
+-            port_db = self._core_plugin._get_port(context, port_id)
+-            if not (port_db['device_owner'] == DEVICE_OWNER_ROUTER_INTF and
+-                    port_db['device_id'] == router_id):
++            owner = interface_info.get('owner', DEVICE_OWNER_ROUTER_INTF)
++            rp_qry = context.session.query(RouterPort)
++            rp_qry = rp_qry.filter_by(port_id=port_id, router_id=router_id,
++                                      port_type=owner)
++            try:
++                router_port = rp_qry.one()
++            except exc.NoResultFound:
+                 raise l3.RouterInterfaceNotFound(router_id=router_id,
+                                                  port_id=port_id)
++            port_db = router_port.port
+             if 'subnet_id' in interface_info:
+                 port_subnet_id = port_db['fixed_ips'][0]['subnet_id']
+                 if port_subnet_id != interface_info['subnet_id']:
+@@ -488,28 +567,43 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                                                       subnet_id)
+ 
+             subnet = self._core_plugin._get_subnet(context, subnet_id)
+-            found = False
+ 
+-            try:
+-                rport_qry = context.session.query(models_v2.Port)
+-                ports = rport_qry.filter_by(
+-                    device_id=router_id,
+-                    device_owner=DEVICE_OWNER_ROUTER_INTF,
+-                    network_id=subnet['network_id'])
+-
+-                for p in ports:
+-                    if p['fixed_ips'][0]['subnet_id'] == subnet_id:
+-                        port_id = p['id']
+-                        self._core_plugin.delete_port(context, p['id'],
+-                                                      l3_port_check=False)
+-                        found = True
+-                        break
+-            except exc.NoResultFound:
+-                pass
++            for rp in router.attached_ports.all():
++                if rp.port_type != DEVICE_OWNER_ROUTER_INTF:
++                    continue
++                elif subnet.network_id != rp.port.network_id:
++                    continue
++
++                port_id = rp.port.id
++
++                if len(set(f['subnet_id'] for f in rp.port.fixed_ips)) == 1:
++                    context.session.delete(rp)
++                    self._core_plugin.delete_port(
++                        context,
++                        port_id,
++                        l3_port_check=False)
++
++                else:
++                    new_fixed_ips = [
++                        {
++                            'subnet_id': fip['subnet_id'],
++                            'ip_address': fip['ip_address']
++                        }
++                        for fip in rp.port.fixed_ips
++                        if fip['subnet_id'] != subnet_id
++                    ]
++
++                    self._core_plugin.update_port(
++                        context,
++                        rp.port.id,
++                        {'port': {'fixed_ips': new_fixed_ips}}
++                    )
++                break
+ 
+-            if not found:
+-                raise l3.RouterInterfaceNotFoundForSubnet(router_id=router_id,
+-                                                          subnet_id=subnet_id)
++            else:
++                raise l3.RouterInterfaceNotFoundForSubnet(
++                    router_id=router_id,
++                    subnet_id=subnet_id)
+         self.l3_rpc_notifier.routers_updated(
+             context, [router_id], 'remove_router_interface')
+         info = {'id': router_id,
+@@ -551,22 +645,18 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                      'which has no gateway_ip') % internal_subnet_id)
+             raise n_exc.BadRequest(resource='floatingip', msg=msg)
+ 
+-        # find router interface ports on this network
+-        router_intf_qry = context.session.query(models_v2.Port)
+-        router_intf_ports = router_intf_qry.filter_by(
+-            network_id=internal_port['network_id'],
+-            device_owner=DEVICE_OWNER_ROUTER_INTF)
+-
+-        for intf_p in router_intf_ports:
+-            if intf_p['fixed_ips'][0]['subnet_id'] == internal_subnet_id:
+-                router_id = intf_p['device_id']
+-                router_gw_qry = context.session.query(models_v2.Port)
+-                has_gw_port = router_gw_qry.filter_by(
+-                    network_id=external_network_id,
+-                    device_id=router_id,
+-                    device_owner=DEVICE_OWNER_ROUTER_GW).count()
+-                if has_gw_port:
+-                    return router_id
++        qry = context.session.query(RouterPort)
++        qry = qry.join(models_v2.Port)
++        qry = qry.join(models_v2.IPAllocation)
++        qry = qry.filter(
++            models_v2.Port.network_id == internal_port['network_id'],
++            RouterPort.port_type == DEVICE_OWNER_ROUTER_INTF,
++            models_v2.IPAllocation.subnet_id == internal_subnet_id
++        )
++
++        routerport = qry.first()
++        if routerport and routerport.router.gw_port:
++            return routerport.router
+ 
+         raise l3.ExternalGatewayForFloatingIPNotFound(
+             subnet_id=internal_subnet_id,
+@@ -632,33 +722,28 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+         """
+         (internal_port, internal_subnet_id,
+          internal_ip_address) = self._internal_fip_assoc_data(context, fip)
+-        router_id = self._get_router_for_floatingip(context,
+-                                                    internal_port,
+-                                                    internal_subnet_id,
+-                                                    floating_network_id)
++        router = self._get_router_for_floatingip(context,
++                                                 internal_port,
++                                                 internal_subnet_id,
++                                                 floating_network_id)
++
+         # confirm that this router has a floating
+         # ip enabled gateway with support for this floating IP network
+-        try:
+-            port_qry = context.elevated().session.query(models_v2.Port)
+-            port_qry.filter_by(
+-                network_id=floating_network_id,
+-                device_id=router_id,
+-                device_owner=DEVICE_OWNER_ROUTER_GW).one()
+-        except exc.NoResultFound:
++        if (not router or not router.gw_port or
++            router.gw_port.network_id != floating_network_id):
+             raise l3.ExternalGatewayForFloatingIPNotFound(
+                 subnet_id=internal_subnet_id,
+                 port_id=internal_port['id'])
+ 
+-        return (fip['port_id'], internal_ip_address, router_id)
++        return (fip['port_id'], internal_ip_address, router['id'])
+ 
+     def _update_fip_assoc(self, context, fip, floatingip_db, external_port):
+         previous_router_id = floatingip_db.router_id
+         port_id = internal_ip_address = router_id = None
+-        if (('fixed_ip_address' in fip and fip['fixed_ip_address']) and
+-            not ('port_id' in fip and fip['port_id'])):
++        if fip.get('fixed_ip_address') and not fip.get('port_id'):
+             msg = _("fixed_ip_address cannot be specified without a port_id")
+             raise n_exc.BadRequest(resource='floatingip', msg=msg)
+-        if 'port_id' in fip and fip['port_id']:
++        if fip.get('port_id'):
+             port_id, internal_ip_address, router_id = self.get_assoc_data(
+                 context,
+                 fip,
+@@ -844,135 +929,16 @@ class L3_NAT_db_mixin(l3.RouterPluginBase):
+                 context, list(router_ids),
+                 'disassociate_floatingips')
+ 
+-    def _build_routers_list(self, routers, gw_ports):
+-        gw_port_id_gw_port_dict = dict((gw_port['id'], gw_port)
+-                                       for gw_port in gw_ports)
+-        for router in routers:
+-            gw_port_id = router['gw_port_id']
+-            if gw_port_id:
+-                router['gw_port'] = gw_port_id_gw_port_dict[gw_port_id]
+-        return routers
+-
+-    def _get_sync_routers(self, context, router_ids=None, active=None):
+-        """Query routers and their gw ports for l3 agent.
+-
+-        Query routers with the router_ids. The gateway ports, if any,
+-        will be queried too.
+-        l3 agent has an option to deal with only one router id. In addition,
+-        when we need to notify the agent the data about only one router
+-        (when modification of router, its interfaces, gw_port and floatingips),
+-        we will have router_ids.
+-        @param router_ids: the list of router ids which we want to query.
+-                           if it is None, all of routers will be queried.
+-        @return: a list of dicted routers with dicted gw_port populated if any
+-        """
+-        filters = {'id': router_ids} if router_ids else {}
+-        if active is not None:
+-            filters['admin_state_up'] = [active]
+-        router_dicts = self.get_routers(context, filters=filters)
+-        gw_port_ids = []
+-        if not router_dicts:
+-            return []
+-        for router_dict in router_dicts:
+-            gw_port_id = router_dict['gw_port_id']
+-            if gw_port_id:
+-                gw_port_ids.append(gw_port_id)
+-        gw_ports = []
+-        if gw_port_ids:
+-            gw_ports = self.get_sync_gw_ports(context, gw_port_ids)
+-        return self._build_routers_list(router_dicts, gw_ports)
+-
+-    def _get_sync_floating_ips(self, context, router_ids):
+-        """Query floating_ips that relate to list of router_ids."""
+-        if not router_ids:
+-            return []
+-        return self.get_floatingips(context, {'router_id': router_ids})
+-
+-    def get_sync_gw_ports(self, context, gw_port_ids):
+-        if not gw_port_ids:
+-            return []
+-        filters = {'id': gw_port_ids}
+-        gw_ports = self._core_plugin.get_ports(context, filters)
+-        if gw_ports:
+-            self._populate_subnet_for_ports(context, gw_ports)
+-        return gw_ports
+-
+-    def get_sync_interfaces(self, context, router_ids,
+-                            device_owner=DEVICE_OWNER_ROUTER_INTF):
+-        """Query router interfaces that relate to list of router_ids."""
+-        if not router_ids:
+-            return []
+-        filters = {'device_id': router_ids,
+-                   'device_owner': [device_owner]}
+-        interfaces = self._core_plugin.get_ports(context, filters)
+-        if interfaces:
+-            self._populate_subnet_for_ports(context, interfaces)
+-        return interfaces
+-
+-    def _populate_subnet_for_ports(self, context, ports):
+-        """Populate ports with subnet.
+-
+-        These ports already have fixed_ips populated.
+-        """
+-        if not ports:
+-            return
+-        subnet_id_ports_dict = {}
+-        for port in ports:
+-            fixed_ips = port.get('fixed_ips', [])
+-            if len(fixed_ips) > 1:
+-                LOG.info(_("Ignoring multiple IPs on router port %s"),
+-                         port['id'])
+-                continue
+-            elif not fixed_ips:
+-                # Skip ports without IPs, which can occur if a subnet
+-                # attached to a router is deleted
+-                LOG.info(_("Skipping port %s as no IP is configure on it"),
+-                         port['id'])
+-                continue
+-            fixed_ip = fixed_ips[0]
+-            my_ports = subnet_id_ports_dict.get(fixed_ip['subnet_id'], [])
+-            my_ports.append(port)
+-            subnet_id_ports_dict[fixed_ip['subnet_id']] = my_ports
+-        if not subnet_id_ports_dict:
+-            return
+-        filters = {'id': subnet_id_ports_dict.keys()}
+-        fields = ['id', 'cidr', 'gateway_ip']
+-        subnet_dicts = self._core_plugin.get_subnets(context, filters, fields)
+-        for subnet_dict in subnet_dicts:
+-            ports = subnet_id_ports_dict.get(subnet_dict['id'], [])
+-            for port in ports:
+-                # TODO(gongysh) stash the subnet into fixed_ips
+-                # to make the payload smaller.
+-                port['subnet'] = {'id': subnet_dict['id'],
+-                                  'cidr': subnet_dict['cidr'],
+-                                  'gateway_ip': subnet_dict['gateway_ip']}
+-
+-    def _process_sync_data(self, routers, interfaces, floating_ips):
+-        routers_dict = {}
+-        for router in routers:
+-            routers_dict[router['id']] = router
+-        for floating_ip in floating_ips:
+-            router = routers_dict.get(floating_ip['router_id'])
+-            if router:
+-                router_floatingips = router.get(l3_constants.FLOATINGIP_KEY,
+-                                                [])
+-                router_floatingips.append(floating_ip)
+-                router[l3_constants.FLOATINGIP_KEY] = router_floatingips
+-        for interface in interfaces:
+-            router = routers_dict.get(interface['device_id'])
+-            if router:
+-                router_interfaces = router.get(l3_constants.INTERFACE_KEY, [])
+-                router_interfaces.append(interface)
+-                router[l3_constants.INTERFACE_KEY] = router_interfaces
+-        return routers_dict.values()
+-
+     def get_sync_data(self, context, router_ids=None, active=None):
+         """Query routers and their related floating_ips, interfaces."""
+         with context.session.begin(subtransactions=True):
+-            routers = self._get_sync_routers(context,
+-                                             router_ids=router_ids,
+-                                             active=active)
+-            router_ids = [router['id'] for router in routers]
+-            floating_ips = self._get_sync_floating_ips(context, router_ids)
+-            interfaces = self.get_sync_interfaces(context, router_ids)
+-        return self._process_sync_data(routers, interfaces, floating_ips)
++            router_query = context.session.query(Router)
++            if router_ids:
++                router_query = router_query.filter(Router.id.in_(router_ids))
++            if active:
++                router_query = router_query.filter_by(admin_state_up=True)
++
++            return [
++                self._make_router_dict(router, depth=2)
++                for router in router_query.all()
++            ]
+diff --git a/neutron/db/models_v2.py b/neutron/db/models_v2.py
+index ab6ecfd..3f3d58c 100644
+--- a/neutron/db/models_v2.py
++++ b/neutron/db/models_v2.py
+@@ -190,6 +190,10 @@ class Subnet(model_base.BASEV2, HasId, HasTenant):
+                                   constants.DHCPV6_STATEFUL,
+                                   constants.DHCPV6_STATELESS,
+                                   name='ipv6_address_modes'), nullable=True)
++    ipallocations = orm.relationship(IPAllocation,
++                                     backref='subnet',
++                                     lazy='dynamic',
++                                     cascade='delete')
+ 
+ 
+ class Network(model_base.BASEV2, HasId, HasTenant):
+diff --git a/neutron/extensions/l3.py b/neutron/extensions/l3.py
+index 6c4de41..274ea4d 100644
+--- a/neutron/extensions/l3.py
++++ b/neutron/extensions/l3.py
+@@ -100,7 +100,9 @@ RESOURCE_ATTRIBUTE_MAP = {
+                       'is_visible': True},
+         EXTERNAL_GW_INFO: {'allow_post': True, 'allow_put': True,
+                            'is_visible': True, 'default': None,
+-                           'enforce_policy': True}
++                           'enforce_policy': True},
++        'ports': {'allow_post': False, 'allow_put': False,
++                  'is_visible': True}
+     },
+     'floatingips': {
+         'id': {'allow_post': False, 'allow_put': False,
+diff --git a/neutron/plugins/nicira/NeutronPlugin.py b/neutron/plugins/nicira/NeutronPlugin.py
+new file mode 100644
+index 0000000..1743a08
+--- /dev/null
++++ b/neutron/plugins/nicira/NeutronPlugin.py
+@@ -0,0 +1,2059 @@
++# vim: tabstop=4 shiftwidth=4 softtabstop=4
++
++# Copyright 2012 Nicira, Inc.
++# All Rights Reserved
++#
++#    Licensed under the Apache License, Version 2.0 (the "License"); you may
++#    not use this file except in compliance with the License. You may obtain
++#    a copy of the License at
++#
++#         http://www.apache.org/licenses/LICENSE-2.0
++#
++#    Unless required by applicable law or agreed to in writing, software
++#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
++#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
++#    License for the specific language governing permissions and limitations
++#    under the License.
++#
++# @author: Somik Behera, Nicira Networks, Inc.
++# @author: Brad Hall, Nicira Networks, Inc.
++# @author: Aaron Rosen, Nicira Networks, Inc.
++
++
++import logging
++import os
++
++from oslo.config import cfg
++from sqlalchemy.orm import exc as sa_exc
++import webob.exc
++
++from neutron.api.v2 import attributes as attr
++from neutron.api.v2 import base
++from neutron.common import constants
++from neutron.common import exceptions as q_exc
++from neutron.common import utils
++from neutron import context as q_context
++from neutron.db import agentschedulers_db
++from neutron.db import allowedaddresspairs_db as addr_pair_db
++from neutron.db import api as db
++from neutron.db import db_base_plugin_v2
++from neutron.db import extraroute_db
++from neutron.db import l3_db
++from neutron.db import l3_gwmode_db
++from neutron.db import models_v2
++from neutron.db import portbindings_db
++from neutron.db import portsecurity_db
++from neutron.db import quota_db  # noqa
++from neutron.db import securitygroups_db
++from neutron.extensions import allowedaddresspairs as addr_pair
++from neutron.extensions import extraroute
++from neutron.extensions import l3
++from neutron.extensions import multiprovidernet as mpnet
++from neutron.extensions import portbindings as pbin
++from neutron.extensions import portsecurity as psec
++from neutron.extensions import providernet as pnet
++from neutron.extensions import securitygroup as ext_sg
++from neutron.openstack.common import excutils
++from neutron.plugins.nicira.common import config
++from neutron.plugins.nicira.common import exceptions as nvp_exc
++from neutron.plugins.nicira.common import securitygroups as nvp_sec
++from neutron.plugins.nicira.common import sync
++from neutron.plugins.nicira.dbexts import distributedrouter as dist_rtr
++from neutron.plugins.nicira.dbexts import maclearning as mac_db
++from neutron.plugins.nicira.dbexts import nicira_db
++from neutron.plugins.nicira.dbexts import nicira_networkgw_db as networkgw_db
++from neutron.plugins.nicira.dbexts import nicira_qos_db as qos_db
++from neutron.plugins.nicira import dhcpmeta_modes
++from neutron.plugins.nicira.extensions import maclearning as mac_ext
++from neutron.plugins.nicira.extensions import nvp_networkgw as networkgw
++from neutron.plugins.nicira.extensions import nvp_qos as ext_qos
++from neutron.plugins.nicira import nvp_cluster
++from neutron.plugins.nicira import NvpApiClient
++from neutron.plugins.nicira import nvplib
++
++
++LOG = logging.getLogger("NeutronPlugin")
++
++NVP_NOSNAT_RULES_ORDER = 10
++NVP_FLOATINGIP_NAT_RULES_ORDER = 224
++NVP_EXTGW_NAT_RULES_ORDER = 255
++NVP_EXT_PATH = os.path.join(os.path.dirname(__file__), 'extensions')
++
++
++# Provider network extension - allowed network types for the NVP Plugin
++class NetworkTypes:
++    """Allowed provider network types for the NVP Plugin."""
++    L3_EXT = 'l3_ext'
++    STT = 'stt'
++    GRE = 'gre'
++    FLAT = 'flat'
++    VLAN = 'vlan'
++    BRIDGE = 'bridge'
++
++
++def create_nvp_cluster(cluster_opts, concurrent_connections,
++                       nvp_gen_timeout):
++    # NOTE(armando-migliaccio): remove this block once we no longer
++    # want to support deprecated options in the nvp config file
++    # ### BEGIN
++    config.register_deprecated(cfg.CONF)
++    # ### END
++    cluster = nvp_cluster.NVPCluster(**cluster_opts)
++    api_providers = [ctrl.split(':') + [True]
++                     for ctrl in cluster.nvp_controllers]
++    cluster.api_client = NvpApiClient.NVPApiHelper(
++        api_providers, cluster.nvp_user, cluster.nvp_password,
++        request_timeout=cluster.req_timeout,
++        http_timeout=cluster.http_timeout,
++        retries=cluster.retries,
++        redirects=cluster.redirects,
++        concurrent_connections=concurrent_connections,
++        nvp_gen_timeout=nvp_gen_timeout)
++    return cluster
++
++
++class NvpPluginV2(addr_pair_db.AllowedAddressPairsMixin,
++                  agentschedulers_db.DhcpAgentSchedulerDbMixin,
++                  db_base_plugin_v2.NeutronDbPluginV2,
++                  dhcpmeta_modes.DhcpMetadataAccess,
++                  dist_rtr.DistributedRouter_mixin,
++                  extraroute_db.ExtraRoute_db_mixin,
++                  l3_gwmode_db.L3_NAT_db_mixin,
++                  mac_db.MacLearningDbMixin,
++                  networkgw_db.NetworkGatewayMixin,
++                  nvp_sec.NVPSecurityGroups,
++                  portbindings_db.PortBindingMixin,
++                  portsecurity_db.PortSecurityDbMixin,
++                  qos_db.NVPQoSDbMixin,
++                  securitygroups_db.SecurityGroupDbMixin):
++    """L2 Virtual network plugin.
++
++    NvpPluginV2 is a Neutron plugin that provides L2 Virtual Network
++    functionality using NVP.
++    """
++
++    supported_extension_aliases = ["agent",
++                                   "allowed-address-pairs",
++                                   "binding",
++                                   "dhcp_agent_scheduler",
++                                   "dist-router",
++                                   "ext-gw-mode",
++                                   "extraroute",
++                                   "mac-learning",
++                                   "multi-provider",
++                                   "network-gateway",
++                                   "nvp-qos",
++                                   "port-security",
++                                   "provider",
++                                   "quotas",
++                                   "router",
++                                   "security-group"]
++
++    __native_bulk_support = True
++
++    # Map nova zones to cluster for easy retrieval
++    novazone_cluster_map = {}
++
++    def __init__(self):
++
++        # TODO(salv-orlando): Replace These dicts with
++        # collections.defaultdict for better handling of default values
++        # Routines for managing logical ports in NVP
++        self._port_drivers = {
++            'create': {l3_db.DEVICE_OWNER_ROUTER_GW:
++                       self._nvp_create_ext_gw_port,
++                       l3_db.DEVICE_OWNER_FLOATINGIP:
++                       self._nvp_create_fip_port,
++                       l3_db.DEVICE_OWNER_ROUTER_INTF:
++                       self._nvp_create_router_port,
++                       networkgw_db.DEVICE_OWNER_NET_GW_INTF:
++                       self._nvp_create_l2_gw_port,
++                       'default': self._nvp_create_port},
++            'delete': {l3_db.DEVICE_OWNER_ROUTER_GW:
++                       self._nvp_delete_ext_gw_port,
++                       l3_db.DEVICE_OWNER_ROUTER_INTF:
++                       self._nvp_delete_router_port,
++                       l3_db.DEVICE_OWNER_FLOATINGIP:
++                       self._nvp_delete_fip_port,
++                       networkgw_db.DEVICE_OWNER_NET_GW_INTF:
++                       self._nvp_delete_port,
++                       'default': self._nvp_delete_port}
++        }
++
++        # If no api_extensions_path is provided set the following
++        if not cfg.CONF.api_extensions_path:
++            cfg.CONF.set_override('api_extensions_path', NVP_EXT_PATH)
++        self.nvp_opts = cfg.CONF.NVP
++        self.nvp_sync_opts = cfg.CONF.NVP_SYNC
++        self.cluster = create_nvp_cluster(cfg.CONF,
++                                          self.nvp_opts.concurrent_connections,
++                                          self.nvp_opts.nvp_gen_timeout)
++
++        self.base_binding_dict = {
++            pbin.VIF_TYPE: pbin.VIF_TYPE_OVS,
++            pbin.CAPABILITIES: {
++                pbin.CAP_PORT_FILTER:
++                'security-group' in self.supported_extension_aliases}}
++
++        db.configure_db()
++        self._extend_fault_map()
++        self.setup_dhcpmeta_access()
++        # Set this flag to false as the default gateway has not
++        # been yet updated from the config file
++        self._is_default_net_gw_in_sync = False
++        # Create a synchronizer instance for backend sync
++        self._synchronizer = sync.NvpSynchronizer(
++            self, self.cluster,
++            self.nvp_sync_opts.state_sync_interval,
++            self.nvp_sync_opts.min_sync_req_delay,
++            self.nvp_sync_opts.min_chunk_size,
++            self.nvp_sync_opts.max_random_sync_delay)
++
++    def _ensure_default_network_gateway(self):
++        if self._is_default_net_gw_in_sync:
++            return
++        # Add the gw in the db as default, and unset any previous default
++        def_l2_gw_uuid = self.cluster.default_l2_gw_service_uuid
++        try:
++            ctx = q_context.get_admin_context()
++            self._unset_default_network_gateways(ctx)
++            if not def_l2_gw_uuid:
++                return
++            try:
++                def_network_gw = self._get_network_gateway(ctx,
++                                                           def_l2_gw_uuid)
++            except sa_exc.NoResultFound:
++                # Create in DB only - don't go on NVP
++                def_gw_data = {'id': def_l2_gw_uuid,
++                               'name': 'default L2 gateway service',
++                               'devices': []}
++                gw_res_name = networkgw.RESOURCE_NAME.replace('-', '_')
++                def_network_gw = super(
++                    NvpPluginV2, self).create_network_gateway(
++                        ctx, {gw_res_name: def_gw_data})
++            # In any case set is as default
++            self._set_default_network_gateway(ctx, def_network_gw['id'])
++            # Ensure this method is executed only once
++            self._is_default_net_gw_in_sync = True
++        except Exception:
++            LOG.exception(_("Unable to process default l2 gw service:%s"),
++                          def_l2_gw_uuid)
++            raise
++
++    def _build_ip_address_list(self, context, fixed_ips, subnet_ids=None):
++        """Build ip_addresses data structure for logical router port.
++
++        No need to perform validation on IPs - this has already been
++        done in the l3_db mixin class.
++        """
++        ip_addresses = []
++        for ip in fixed_ips:
++            if not subnet_ids or (ip['subnet_id'] in subnet_ids):
++                subnet = self._get_subnet(context, ip['subnet_id'])
++                ip_prefix = '%s/%s' % (ip['ip_address'],
++                                       subnet['cidr'].split('/')[1])
++                ip_addresses.append(ip_prefix)
++        return ip_addresses
++
++    def _create_and_attach_router_port(self, cluster, context,
++                                       router_id, port_data,
++                                       attachment_type, attachment,
++                                       attachment_vlan=None,
++                                       subnet_ids=None):
++        # Use a fake IP address if gateway port is not 'real'
++        ip_addresses = (port_data.get('fake_ext_gw') and
++                        ['0.0.0.0/31'] or
++                        self._build_ip_address_list(context,
++                                                    port_data['fixed_ips'],
++                                                    subnet_ids))
++        try:
++            lrouter_port = nvplib.create_router_lport(
++                cluster, router_id, port_data.get('tenant_id', 'fake'),
++                port_data.get('id', 'fake'), port_data.get('name', 'fake'),
++                port_data.get('admin_state_up', True), ip_addresses)
++            LOG.debug(_("Created NVP router port:%s"), lrouter_port['uuid'])
++        except NvpApiClient.NvpApiException:
++            LOG.exception(_("Unable to create port on NVP logical router %s"),
++                          router_id)
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Unable to create logical router port for neutron "
++                          "port id %(port_id)s on router %(router_id)s") %
++                {'port_id': port_data.get('id'), 'router_id': router_id})
++        self._update_router_port_attachment(cluster, context, router_id,
++                                            port_data, lrouter_port['uuid'],
++                                            attachment_type, attachment,
++                                            attachment_vlan)
++        return lrouter_port
++
++    def _update_router_gw_info(self, context, router_id, info):
++        # NOTE(salvatore-orlando): We need to worry about rollback of NVP
++        # configuration in case of failures in the process
++        # Ref. LP bug 1102301
++        router = self._get_router(context, router_id)
++        # Check whether SNAT rule update should be triggered
++        # NVP also supports multiple external networks so there is also
++        # the possibility that NAT rules should be replaced
++        current_ext_net_id = router.gw_port_id and router.gw_port.network_id
++        new_ext_net_id = info and info.get('network_id')
++        # SNAT should be enabled unless info['enable_snat'] is
++        # explicitly set to false
++        enable_snat = new_ext_net_id and info.get('enable_snat', True)
++        # Remove if ext net removed, changed, or if snat disabled
++        remove_snat_rules = (current_ext_net_id and
++                             new_ext_net_id != current_ext_net_id or
++                             router.enable_snat and not enable_snat)
++        # Add rules if snat is enabled, and if either the external network
++        # changed or snat was previously disabled
++        # NOTE: enable_snat == True implies new_ext_net_id != None
++        add_snat_rules = (enable_snat and
++                          (new_ext_net_id != current_ext_net_id or
++                           not router.enable_snat))
++        router = super(NvpPluginV2, self)._update_router_gw_info(
++            context, router_id, info, router=router)
++        # Add/Remove SNAT rules as needed
++        # Create an elevated context for dealing with metadata access
++        # cidrs which are created within admin context
++        ctx_elevated = context.elevated()
++        if remove_snat_rules or add_snat_rules:
++            cidrs = self._find_router_subnets_cidrs(ctx_elevated, router_id)
++        if remove_snat_rules:
++            # Be safe and concede NAT rules might not exist.
++            # Therefore use min_num_expected=0
++            for cidr in cidrs:
++                nvplib.delete_nat_rules_by_match(
++                    self.cluster, router_id, "SourceNatRule",
++                    max_num_expected=1, min_num_expected=0,
++                    source_ip_addresses=cidr)
++        if add_snat_rules:
++            ip_addresses = self._build_ip_address_list(
++                ctx_elevated, router.gw_port['fixed_ips'])
++            # Set the SNAT rule for each subnet (only first IP)
++            for cidr in cidrs:
++                cidr_prefix = int(cidr.split('/')[1])
++                nvplib.create_lrouter_snat_rule(
++                    self.cluster, router_id,
++                    ip_addresses[0].split('/')[0],
++                    ip_addresses[0].split('/')[0],
++                    order=NVP_EXTGW_NAT_RULES_ORDER - cidr_prefix,
++                    match_criteria={'source_ip_addresses': cidr})
++
++    def _update_router_port_attachment(self, cluster, context,
++                                       router_id, port_data,
++                                       nvp_router_port_id,
++                                       attachment_type,
++                                       attachment,
++                                       attachment_vlan=None):
++        if not nvp_router_port_id:
++            nvp_router_port_id = self._find_router_gw_port(context, port_data)
++        try:
++            nvplib.plug_router_port_attachment(cluster, router_id,
++                                               nvp_router_port_id,
++                                               attachment,
++                                               attachment_type,
++                                               attachment_vlan)
++            LOG.debug(_("Attached %(att)s to NVP router port %(port)s"),
++                      {'att': attachment, 'port': nvp_router_port_id})
++        except NvpApiClient.NvpApiException:
++            # Must remove NVP logical port
++            nvplib.delete_router_lport(cluster, router_id,
++                                       nvp_router_port_id)
++            LOG.exception(_("Unable to plug attachment in NVP logical "
++                            "router port %(r_port_id)s, associated with "
++                            "Neutron %(q_port_id)s"),
++                          {'r_port_id': nvp_router_port_id,
++                           'q_port_id': port_data.get('id')})
++            raise nvp_exc.NvpPluginException(
++                err_msg=(_("Unable to plug attachment in router port "
++                           "%(r_port_id)s for neutron port id %(q_port_id)s "
++                           "on router %(router_id)s") %
++                         {'r_port_id': nvp_router_port_id,
++                          'q_port_id': port_data.get('id'),
++                          'router_id': router_id}))
++
++    def _get_port_by_device_id(self, context, device_id, device_owner):
++        """Retrieve ports associated with a specific device id.
++
++        Used for retrieving all neutron ports attached to a given router.
++        """
++        port_qry = context.session.query(models_v2.Port)
++        return port_qry.filter_by(
++            device_id=device_id,
++            device_owner=device_owner,).all()
++
++    def _find_router_subnets_cidrs(self, context, router_id):
++        """Retrieve subnets attached to the specified router."""
++        ports = self._get_port_by_device_id(context, router_id,
++                                            l3_db.DEVICE_OWNER_ROUTER_INTF)
++        # No need to check for overlapping CIDRs
++        cidrs = []
++        for port in ports:
++            for ip in port.get('fixed_ips', []):
++                cidrs.append(self._get_subnet(context,
++                                              ip.subnet_id).cidr)
++        return cidrs
++
++    def _nvp_find_lswitch_for_port(self, context, port_data):
++        network = self._get_network(context, port_data['network_id'])
++        network_bindings = nicira_db.get_network_bindings(
++            context.session, port_data['network_id'])
++        max_ports = self.nvp_opts.max_lp_per_overlay_ls
++        allow_extra_lswitches = False
++        for network_binding in network_bindings:
++            if network_binding.binding_type in (NetworkTypes.FLAT,
++                                                NetworkTypes.VLAN):
++                max_ports = self.nvp_opts.max_lp_per_bridged_ls
++                allow_extra_lswitches = True
++                break
++        try:
++            return self._handle_lswitch_selection(self.cluster, network,
++                                                  network_bindings, max_ports,
++                                                  allow_extra_lswitches)
++        except NvpApiClient.NvpApiException:
++            err_desc = _("An exception occured while selecting logical "
++                         "switch for the port")
++            LOG.exception(err_desc)
++            raise nvp_exc.NvpPluginException(err_msg=err_desc)
++
++    def _nvp_create_port_helper(self, cluster, ls_uuid, port_data,
++                                do_port_security=True):
++        return nvplib.create_lport(cluster, ls_uuid, port_data['tenant_id'],
++                                   port_data['id'], port_data['name'],
++                                   port_data['device_id'],
++                                   port_data['admin_state_up'],
++                                   port_data['mac_address'],
++                                   port_data['fixed_ips'],
++                                   port_data[psec.PORTSECURITY],
++                                   port_data[ext_sg.SECURITYGROUPS],
++                                   port_data[ext_qos.QUEUE],
++                                   port_data.get(mac_ext.MAC_LEARNING),
++                                   port_data.get(addr_pair.ADDRESS_PAIRS))
++
++    def _handle_create_port_exception(self, context, port_id,
++                                      ls_uuid, lp_uuid):
++        with excutils.save_and_reraise_exception():
++            # rollback nvp logical port only if it was successfully
++            # created on NVP. Should this command fail the original
++            # exception will be raised.
++            if lp_uuid:
++                # Remove orphaned port from NVP
++                nvplib.delete_port(self.cluster, ls_uuid, lp_uuid)
++            # rollback the neutron-nvp port mapping
++            nicira_db.delete_neutron_nvp_port_mapping(context.session,
++                                                      port_id)
++            msg = (_("An exception occured while creating the "
++                     "quantum port %s on the NVP plaform") % port_id)
++            LOG.exception(msg)
++
++    def _nvp_create_port(self, context, port_data):
++        """Driver for creating a logical switch port on NVP platform."""
++        # FIXME(salvatore-orlando): On the NVP platform we do not really have
++        # external networks. So if as user tries and create a "regular" VIF
++        # port on an external network we are unable to actually create.
++        # However, in order to not break unit tests, we need to still create
++        # the DB object and return success
++        if self._network_is_external(context, port_data['network_id']):
++            LOG.error(_("NVP plugin does not support regular VIF ports on "
++                        "external networks. Port %s will be down."),
++                      port_data['network_id'])
++            # No need to actually update the DB state - the default is down
++            return port_data
++        lport = None
++        selected_lswitch = None
++        try:
++            selected_lswitch = self._nvp_find_lswitch_for_port(context,
++                                                               port_data)
++            lport = self._nvp_create_port_helper(self.cluster,
++                                                 selected_lswitch['uuid'],
++                                                 port_data,
++                                                 True)
++            nicira_db.add_neutron_nvp_port_mapping(
++                context.session, port_data['id'], lport['uuid'])
++            if (not port_data['device_owner'] in
++                (l3_db.DEVICE_OWNER_ROUTER_GW,
++                 l3_db.DEVICE_OWNER_ROUTER_INTF)):
++                nvplib.plug_interface(self.cluster, selected_lswitch['uuid'],
++                                      lport['uuid'], "VifAttachment",
++                                      port_data['id'])
++            LOG.debug(_("_nvp_create_port completed for port %(name)s "
++                        "on network %(network_id)s. The new port id is "
++                        "%(id)s."), port_data)
++        except (NvpApiClient.NvpApiException, q_exc.NeutronException):
++            self._handle_create_port_exception(
++                context, port_data['id'],
++                selected_lswitch and selected_lswitch['uuid'],
++                lport and lport['uuid'])
++
++    def _nvp_delete_port(self, context, port_data):
++        # FIXME(salvatore-orlando): On the NVP platform we do not really have
++        # external networks. So deleting regular ports from external networks
++        # does not make sense. However we cannot raise as this would break
++        # unit tests.
++        if self._network_is_external(context, port_data['network_id']):
++            LOG.error(_("NVP plugin does not support regular VIF ports on "
++                        "external networks. Port %s will be down."),
++                      port_data['network_id'])
++            return
++        nvp_port_id = self._nvp_get_port_id(context, self.cluster,
++                                            port_data)
++        if not nvp_port_id:
++            LOG.debug(_("Port '%s' was already deleted on NVP platform"), id)
++            return
++        # TODO(bgh): if this is a bridged network and the lswitch we just got
++        # back will have zero ports after the delete we should garbage collect
++        # the lswitch.
++        try:
++            nvplib.delete_port(self.cluster,
++                               port_data['network_id'],
++                               nvp_port_id)
++            LOG.debug(_("_nvp_delete_port completed for port %(port_id)s "
++                        "on network %(net_id)s"),
++                      {'port_id': port_data['id'],
++                       'net_id': port_data['network_id']})
++
++        except q_exc.NotFound:
++            LOG.warning(_("port %s not found in NVP"), port_data['id'])
++
++    def _nvp_delete_router_port(self, context, port_data):
++        # Delete logical router port
++        lrouter_id = port_data['device_id']
++        nvp_port_id = self._nvp_get_port_id(context, self.cluster,
++                                            port_data)
++        if not nvp_port_id:
++            raise q_exc.PortNotFound(port_id=port_data['id'])
++
++        try:
++            nvplib.delete_peer_router_lport(self.cluster,
++                                            lrouter_id,
++                                            port_data['network_id'],
++                                            nvp_port_id)
++        except NvpApiClient.NvpApiException:
++            # Do not raise because the issue might as well be that the
++            # router has already been deleted, so there would be nothing
++            # to do here
++            LOG.exception(_("Ignoring exception as this means the peer "
++                            "for port '%s' has already been deleted."),
++                          nvp_port_id)
++
++        # Delete logical switch port
++        self._nvp_delete_port(context, port_data)
++
++    def _nvp_create_router_port(self, context, port_data):
++        """Driver for creating a switch port to be connected to a router."""
++        # No router ports on external networks!
++        if self._network_is_external(context, port_data['network_id']):
++            raise nvp_exc.NvpPluginException(
++                err_msg=(_("It is not allowed to create router interface "
++                           "ports on external networks as '%s'") %
++                         port_data['network_id']))
++        ls_port = None
++        selected_lswitch = None
++        try:
++            selected_lswitch = self._nvp_find_lswitch_for_port(
++                context, port_data)
++            # Do not apply port security here!
++            ls_port = self._nvp_create_port_helper(
++                self.cluster, selected_lswitch['uuid'],
++                port_data, False)
++            # Assuming subnet being attached is on first fixed ip
++            # element in port data
++            subnet_id = port_data['fixed_ips'][0]['subnet_id']
++            router_id = port_data['device_id']
++            # Create peer port on logical router
++            self._create_and_attach_router_port(
++                self.cluster, context, router_id, port_data,
++                "PatchAttachment", ls_port['uuid'],
++                subnet_ids=[subnet_id])
++            nicira_db.add_neutron_nvp_port_mapping(
++                context.session, port_data['id'], ls_port['uuid'])
++            LOG.debug(_("_nvp_create_router_port completed for port "
++                        "%(name)s on network %(network_id)s. The new "
++                        "port id is %(id)s."),
++                      port_data)
++        except (NvpApiClient.NvpApiException, q_exc.NeutronException):
++            self._handle_create_port_exception(
++                context, port_data['id'],
++                selected_lswitch and selected_lswitch['uuid'],
++                ls_port and ls_port['uuid'])
++
++    def _find_router_gw_port(self, context, port_data):
++        router_id = port_data['device_id']
++        if not router_id:
++            raise q_exc.BadRequest(_("device_id field must be populated in "
++                                   "order to create an external gateway "
++                                   "port for network %s"),
++                                   port_data['network_id'])
++
++        lr_port = nvplib.find_router_gw_port(context, self.cluster, router_id)
++        if not lr_port:
++            raise nvp_exc.NvpPluginException(
++                err_msg=(_("The gateway port for the router %s "
++                           "was not found on the NVP backend")
++                         % router_id))
++        return lr_port
++
++    def _nvp_create_ext_gw_port(self, context, port_data):
++        """Driver for creating an external gateway port on NVP platform."""
++        # TODO(salvatore-orlando): Handle NVP resource
++        # rollback when something goes not quite as expected
++        lr_port = self._find_router_gw_port(context, port_data)
++        ip_addresses = self._build_ip_address_list(context,
++                                                   port_data['fixed_ips'])
++        # This operation actually always updates a NVP logical port
++        # instead of creating one. This is because the gateway port
++        # is created at the same time as the NVP logical router, otherwise
++        # the fabric status of the NVP router will be down.
++        # admin_status should always be up for the gateway port
++        # regardless of what the user specifies in neutron
++        router_id = port_data['device_id']
++        nvplib.update_router_lport(self.cluster,
++                                   router_id,
++                                   lr_port['uuid'],
++                                   port_data['tenant_id'],
++                                   port_data['id'],
++                                   port_data['name'],
++                                   True,
++                                   ip_addresses)
++        ext_network = self.get_network(context, port_data['network_id'])
++        if ext_network.get(pnet.NETWORK_TYPE) == NetworkTypes.L3_EXT:
++            # Update attachment
++            self._update_router_port_attachment(
++                self.cluster, context, router_id, port_data,
++                lr_port['uuid'],
++                "L3GatewayAttachment",
++                ext_network[pnet.PHYSICAL_NETWORK],
++                ext_network[pnet.SEGMENTATION_ID])
++
++        LOG.debug(_("_nvp_create_ext_gw_port completed on external network "
++                    "%(ext_net_id)s, attached to router:%(router_id)s. "
++                    "NVP port id is %(nvp_port_id)s"),
++                  {'ext_net_id': port_data['network_id'],
++                   'router_id': router_id,
++                   'nvp_port_id': lr_port['uuid']})
++
++    def _nvp_delete_ext_gw_port(self, context, port_data):
++        lr_port = self._find_router_gw_port(context, port_data)
++        # TODO(salvatore-orlando): Handle NVP resource
++        # rollback when something goes not quite as expected
++        try:
++            # Delete is actually never a real delete, otherwise the NVP
++            # logical router will stop working
++            router_id = port_data['device_id']
++            nvplib.update_router_lport(self.cluster,
++                                       router_id,
++                                       lr_port['uuid'],
++                                       port_data['tenant_id'],
++                                       port_data['id'],
++                                       port_data['name'],
++                                       True,
++                                       ['0.0.0.0/31'])
++            # Reset attachment
++            self._update_router_port_attachment(
++                self.cluster, context, router_id, port_data,
++                lr_port['uuid'],
++                "L3GatewayAttachment",
++                self.cluster.default_l3_gw_service_uuid)
++
++        except NvpApiClient.ResourceNotFound:
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Logical router resource %s not found "
++                          "on NVP platform") % router_id)
++        except NvpApiClient.NvpApiException:
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Unable to update logical router"
++                          "on NVP Platform"))
++        LOG.debug(_("_nvp_delete_ext_gw_port completed on external network "
++                    "%(ext_net_id)s, attached to router:%(router_id)s"),
++                  {'ext_net_id': port_data['network_id'],
++                   'router_id': router_id})
++
++    def _nvp_create_l2_gw_port(self, context, port_data):
++        """Create a switch port, and attach it to a L2 gateway attachment."""
++        # FIXME(salvatore-orlando): On the NVP platform we do not really have
++        # external networks. So if as user tries and create a "regular" VIF
++        # port on an external network we are unable to actually create.
++        # However, in order to not break unit tests, we need to still create
++        # the DB object and return success
++        if self._network_is_external(context, port_data['network_id']):
++            LOG.error(_("NVP plugin does not support regular VIF ports on "
++                        "external networks. Port %s will be down."),
++                      port_data['network_id'])
++            # No need to actually update the DB state - the default is down
++            return port_data
++        lport = None
++        try:
++            selected_lswitch = self._nvp_find_lswitch_for_port(
++                context, port_data)
++            lport = self._nvp_create_port_helper(
++                self.cluster,
++                selected_lswitch['uuid'],
++                port_data,
++                True)
++            nicira_db.add_neutron_nvp_port_mapping(
++                context.session, port_data['id'], lport['uuid'])
++            nvplib.plug_l2_gw_service(
++                self.cluster,
++                port_data['network_id'],
++                lport['uuid'],
++                port_data['device_id'],
++                int(port_data.get('gw:segmentation_id') or 0))
++        except Exception:
++            with excutils.save_and_reraise_exception():
++                if lport:
++                    nvplib.delete_port(self.cluster,
++                                       selected_lswitch['uuid'],
++                                       lport['uuid'])
++        LOG.debug(_("_nvp_create_l2_gw_port completed for port %(name)s "
++                    "on network %(network_id)s. The new port id "
++                    "is %(id)s."), port_data)
++
++    def _nvp_create_fip_port(self, context, port_data):
++        # As we do not create ports for floating IPs in NVP,
++        # this is a no-op driver
++        pass
++
++    def _nvp_delete_fip_port(self, context, port_data):
++        # As we do not create ports for floating IPs in NVP,
++        # this is a no-op driver
++        pass
++
++    def _nvp_get_port_id(self, context, cluster, neutron_port):
++        """Return the NVP port uuid for a given neutron port.
++
++        First, look up the Neutron database. If not found, execute
++        a query on NVP platform as the mapping might be missing because
++        the port was created before upgrading to grizzly.
++        """
++        nvp_port_id = nicira_db.get_nvp_port_id(context.session,
++                                                neutron_port['id'])
++        if nvp_port_id:
++            return nvp_port_id
++        # Perform a query to NVP and then update the DB
++        try:
++            nvp_port = nvplib.get_port_by_neutron_tag(
++                cluster,
++                neutron_port['network_id'],
++                neutron_port['id'])
++            if nvp_port:
++                nicira_db.add_neutron_nvp_port_mapping(
++                    context.session,
++                    neutron_port['id'],
++                    nvp_port['uuid'])
++                return nvp_port['uuid']
++        except Exception:
++            LOG.exception(_("Unable to find NVP uuid for Neutron port %s"),
++                          neutron_port['id'])
++
++    def _extend_fault_map(self):
++        """Extends the Neutron Fault Map.
++
++        Exceptions specific to the NVP Plugin are mapped to standard
++        HTTP Exceptions.
++        """
++        base.FAULT_MAP.update({nvp_exc.NvpInvalidNovaZone:
++                               webob.exc.HTTPBadRequest,
++                               nvp_exc.NvpNoMorePortsException:
++                               webob.exc.HTTPBadRequest,
++                               nvp_exc.MaintenanceInProgress:
++                               webob.exc.HTTPServiceUnavailable})
++
++    def _validate_provider_create(self, context, network):
++        if not attr.is_attr_set(network.get(mpnet.SEGMENTS)):
++            return
++
++        for segment in network[mpnet.SEGMENTS]:
++            network_type = segment.get(pnet.NETWORK_TYPE)
++            physical_network = segment.get(pnet.PHYSICAL_NETWORK)
++            segmentation_id = segment.get(pnet.SEGMENTATION_ID)
++            network_type_set = attr.is_attr_set(network_type)
++            segmentation_id_set = attr.is_attr_set(segmentation_id)
++
++            err_msg = None
++            if not network_type_set:
++                err_msg = _("%s required") % pnet.NETWORK_TYPE
++            elif network_type in (NetworkTypes.GRE, NetworkTypes.STT,
++                                  NetworkTypes.FLAT):
++                if segmentation_id_set:
++                    err_msg = _("Segmentation ID cannot be specified with "
++                                "flat network type")
++            elif network_type == NetworkTypes.VLAN:
++                if not segmentation_id_set:
++                    err_msg = _("Segmentation ID must be specified with "
++                                "vlan network type")
++                elif (segmentation_id_set and
++                      not utils.is_valid_vlan_tag(segmentation_id)):
++                    err_msg = (_("%(segmentation_id)s out of range "
++                                 "(%(min_id)s through %(max_id)s)") %
++                               {'segmentation_id': segmentation_id,
++                                'min_id': constants.MIN_VLAN_TAG,
++                                'max_id': constants.MAX_VLAN_TAG})
++                else:
++                    # Verify segment is not already allocated
++                    bindings = nicira_db.get_network_bindings_by_vlanid(
++                        context.session, segmentation_id)
++                    if bindings:
++                        raise q_exc.VlanIdInUse(
++                            vlan_id=segmentation_id,
++                            physical_network=physical_network)
++            elif network_type == NetworkTypes.L3_EXT:
++                if (segmentation_id_set and
++                    not utils.is_valid_vlan_tag(segmentation_id)):
++                    err_msg = (_("%(segmentation_id)s out of range "
++                                 "(%(min_id)s through %(max_id)s)") %
++                               {'segmentation_id': segmentation_id,
++                                'min_id': constants.MIN_VLAN_TAG,
++                                'max_id': constants.MAX_VLAN_TAG})
++            else:
++                err_msg = (_("%(net_type_param)s %(net_type_value)s not "
++                             "supported") %
++                           {'net_type_param': pnet.NETWORK_TYPE,
++                            'net_type_value': network_type})
++            if err_msg:
++                raise q_exc.InvalidInput(error_message=err_msg)
++            # TODO(salvatore-orlando): Validate tranport zone uuid
++            # which should be specified in physical_network
++
++    def _extend_network_dict_provider(self, context, network,
++                                      multiprovider=None, bindings=None):
++        if not bindings:
++            bindings = nicira_db.get_network_bindings(context.session,
++                                                      network['id'])
++        if not multiprovider:
++            multiprovider = nicira_db.is_multiprovider_network(context.session,
++                                                               network['id'])
++        # With NVP plugin 'normal' overlay networks will have no binding
++        # TODO(salvatore-orlando) make sure users can specify a distinct
++        # phy_uuid as 'provider network' for STT net type
++        if bindings:
++            if not multiprovider:
++                # network came in through provider networks api
++                network[pnet.NETWORK_TYPE] = bindings[0].binding_type
++                network[pnet.PHYSICAL_NETWORK] = bindings[0].phy_uuid
++                network[pnet.SEGMENTATION_ID] = bindings[0].vlan_id
++            else:
++                # network come in though multiprovider networks api
++                network[mpnet.SEGMENTS] = [
++                    {pnet.NETWORK_TYPE: binding.binding_type,
++                     pnet.PHYSICAL_NETWORK: binding.phy_uuid,
++                     pnet.SEGMENTATION_ID: binding.vlan_id}
++                    for binding in bindings]
++
++    def _handle_lswitch_selection(self, cluster, network,
++                                  network_bindings, max_ports,
++                                  allow_extra_lswitches):
++        lswitches = nvplib.get_lswitches(cluster, network.id)
++        try:
++            # TODO(salvatore-orlando) find main_ls too!
++            return [ls for ls in lswitches
++                    if (ls['_relations']['LogicalSwitchStatus']
++                        ['lport_count'] < max_ports)].pop(0)
++        except IndexError:
++            # Too bad, no switch available
++            LOG.debug(_("No switch has available ports (%d checked)"),
++                      len(lswitches))
++        if allow_extra_lswitches:
++            main_ls = [ls for ls in lswitches if ls['uuid'] == network.id]
++            tag_dict = dict((x['scope'], x['tag']) for x in main_ls[0]['tags'])
++            if 'multi_lswitch' not in tag_dict:
++                tags = main_ls[0]['tags']
++                tags.append({'tag': 'True', 'scope': 'multi_lswitch'})
++                nvplib.update_lswitch(cluster,
++                                      main_ls[0]['uuid'],
++                                      main_ls[0]['display_name'],
++                                      network['tenant_id'],
++                                      tags=tags)
++            transport_zone_config = self._convert_to_nvp_transport_zones(
++                cluster, bindings=network_bindings)
++            selected_lswitch = nvplib.create_lswitch(
++                cluster, network.tenant_id,
++                "%s-ext-%s" % (network.name, len(lswitches)),
++                transport_zone_config,
++                network.id)
++            return selected_lswitch
++        else:
++            LOG.error(_("Maximum number of logical ports reached for "
++                        "logical network %s"), network.id)
++            raise nvp_exc.NvpNoMorePortsException(network=network.id)
++
++    def _convert_to_nvp_transport_zones(self, cluster, network=None,
++                                        bindings=None):
++        nvp_transport_zones_config = []
++
++        # Convert fields from provider request to nvp format
++        if (network and not attr.is_attr_set(
++            network.get(mpnet.SEGMENTS))):
++            return [{"zone_uuid": cluster.default_tz_uuid,
++                     "transport_type": cfg.CONF.NVP.default_transport_type}]
++
++        # Convert fields from db to nvp format
++        if bindings:
++            transport_entry = {}
++            for binding in bindings:
++                if binding.binding_type in [NetworkTypes.FLAT,
++                                            NetworkTypes.VLAN]:
++                    transport_entry['transport_type'] = NetworkTypes.BRIDGE
++                    transport_entry['binding_config'] = {}
++                    vlan_id = binding.vlan_id
++                    if vlan_id:
++                        transport_entry['binding_config'] = (
++                            {'vlan_translation': [{'transport': vlan_id}]})
++                else:
++                    transport_entry['transport_type'] = binding.binding_type
++                transport_entry['zone_uuid'] = binding.phy_uuid
++                nvp_transport_zones_config.append(transport_entry)
++            return nvp_transport_zones_config
++
++        for transport_zone in network.get(mpnet.SEGMENTS):
++            for value in [pnet.NETWORK_TYPE, pnet.PHYSICAL_NETWORK,
++                          pnet.SEGMENTATION_ID]:
++                if transport_zone.get(value) == attr.ATTR_NOT_SPECIFIED:
++                    transport_zone[value] = None
++
++            transport_entry = {}
++            transport_type = transport_zone.get(pnet.NETWORK_TYPE)
++            if transport_type in [NetworkTypes.FLAT, NetworkTypes.VLAN]:
++                transport_entry['transport_type'] = NetworkTypes.BRIDGE
++                transport_entry['binding_config'] = {}
++                vlan_id = transport_zone.get(pnet.SEGMENTATION_ID)
++                if vlan_id:
++                    transport_entry['binding_config'] = (
++                        {'vlan_translation': [{'transport': vlan_id}]})
++            else:
++                transport_entry['transport_type'] = transport_type
++            transport_entry['zone_uuid'] = (
++                transport_zone[pnet.PHYSICAL_NETWORK] or
++                cluster.deafult_tz_uuid)
++            nvp_transport_zones_config.append(transport_entry)
++        return nvp_transport_zones_config
++
++    def _convert_to_transport_zones_dict(self, network):
++        """Converts the provider request body to multiprovider.
++        Returns: True if request is multiprovider False if provider
++        and None if neither.
++        """
++        if any(attr.is_attr_set(network.get(f))
++               for f in (pnet.NETWORK_TYPE, pnet.PHYSICAL_NETWORK,
++                         pnet.SEGMENTATION_ID)):
++            if attr.is_attr_set(network.get(mpnet.SEGMENTS)):
++                raise mpnet.SegmentsSetInConjunctionWithProviders()
++            # convert to transport zone list
++            network[mpnet.SEGMENTS] = [
++                {pnet.NETWORK_TYPE: network[pnet.NETWORK_TYPE],
++                 pnet.PHYSICAL_NETWORK: network[pnet.PHYSICAL_NETWORK],
++                 pnet.SEGMENTATION_ID: network[pnet.SEGMENTATION_ID]}]
++            del network[pnet.NETWORK_TYPE]
++            del network[pnet.PHYSICAL_NETWORK]
++            del network[pnet.SEGMENTATION_ID]
++            return False
++        if attr.is_attr_set(mpnet.SEGMENTS):
++            return True
++
++    def create_network(self, context, network):
++        net_data = network['network']
++        tenant_id = self._get_tenant_id_for_create(context, net_data)
++        self._ensure_default_security_group(context, tenant_id)
++        # Process the provider network extension
++        provider_type = self._convert_to_transport_zones_dict(net_data)
++        self._validate_provider_create(context, net_data)
++        # Replace ATTR_NOT_SPECIFIED with None before sending to NVP
++        for key, value in network['network'].iteritems():
++            if value is attr.ATTR_NOT_SPECIFIED:
++                net_data[key] = None
++        # FIXME(arosen) implement admin_state_up = False in NVP
++        if net_data['admin_state_up'] is False:
++            LOG.warning(_("Network with admin_state_up=False are not yet "
++                          "supported by this plugin. Ignoring setting for "
++                          "network %s"), net_data.get('name', '<unknown>'))
++        transport_zone_config = self._convert_to_nvp_transport_zones(
++            self.cluster, net_data)
++        external = net_data.get(l3.EXTERNAL)
++        if (not attr.is_attr_set(external) or
++            attr.is_attr_set(external) and not external):
++            lswitch = nvplib.create_lswitch(
++                self.cluster, tenant_id, net_data.get('name'),
++                transport_zone_config,
++                shared=net_data.get(attr.SHARED))
++            net_data['id'] = lswitch['uuid']
++
++        with context.session.begin(subtransactions=True):
++            new_net = super(NvpPluginV2, self).create_network(context,
++                                                              network)
++            # Ensure there's an id in net_data
++            net_data['id'] = new_net['id']
++            # Process port security extension
++            self._process_network_port_security_create(
++                context, net_data, new_net)
++            # DB Operations for setting the network as external
++            self._process_l3_create(context, new_net, net_data)
++            # Process QoS queue extension
++            if network['network'].get(ext_qos.QUEUE):
++                new_net[ext_qos.QUEUE] = network['network'][ext_qos.QUEUE]
++                # Raises if not found
++                self.get_qos_queue(context, new_net[ext_qos.QUEUE])
++                self._process_network_queue_mapping(context, new_net)
++                self._extend_network_qos_queue(context, new_net)
++
++            if (net_data.get(mpnet.SEGMENTS) and
++                isinstance(provider_type, bool)):
++                net_bindings = []
++                for tz in net_data[mpnet.SEGMENTS]:
++                    net_bindings.append(nicira_db.add_network_binding(
++                        context.session, new_net['id'],
++                        tz.get(pnet.NETWORK_TYPE),
++                        tz.get(pnet.PHYSICAL_NETWORK),
++                        tz.get(pnet.SEGMENTATION_ID, 0)))
++                if provider_type:
++                    nicira_db.set_multiprovider_network(context.session,
++                                                        new_net['id'])
++                self._extend_network_dict_provider(context, new_net,
++                                                   provider_type,
++                                                   net_bindings)
++        self.handle_network_dhcp_access(context, new_net,
++                                        action='create_network')
++        return new_net
++
++    def delete_network(self, context, id):
++        external = self._network_is_external(context, id)
++        # Before deleting ports, ensure the peer of a NVP logical
++        # port with a patch attachment is removed too
++        port_filter = {'network_id': [id],
++                       'device_owner': ['network:router_interface']}
++        router_iface_ports = self.get_ports(context, filters=port_filter)
++        for port in router_iface_ports:
++            nvp_port_id = self._nvp_get_port_id(
++                context, self.cluster, port)
++            if nvp_port_id:
++                port['nvp_port_id'] = nvp_port_id
++            else:
++                LOG.warning(_("A nvp lport identifier was not found for "
++                              "neutron port '%s'"), port['id'])
++
++        super(NvpPluginV2, self).delete_network(context, id)
++        # clean up network owned ports
++        for port in router_iface_ports:
++            try:
++                if 'nvp_port_id' in port:
++                    nvplib.delete_peer_router_lport(self.cluster,
++                                                    port['device_id'],
++                                                    port['network_id'],
++                                                    port['nvp_port_id'])
++            except (TypeError, KeyError,
++                    NvpApiClient.NvpApiException,
++                    NvpApiClient.ResourceNotFound):
++                # Do not raise because the issue might as well be that the
++                # router has already been deleted, so there would be nothing
++                # to do here
++                LOG.warning(_("Ignoring exception as this means the peer for "
++                              "port '%s' has already been deleted."),
++                            nvp_port_id)
++
++        # Do not go to NVP for external networks
++        if not external:
++            try:
++                lswitch_ids = [ls['uuid'] for ls in
++                               nvplib.get_lswitches(self.cluster, id)]
++                nvplib.delete_networks(self.cluster, id, lswitch_ids)
++                LOG.debug(_("delete_network completed for tenant: %s"),
++                          context.tenant_id)
++            except q_exc.NotFound:
++                LOG.warning(_("Did not found lswitch %s in NVP"), id)
++        self.handle_network_dhcp_access(context, id, action='delete_network')
++
++    def get_network(self, context, id, fields=None):
++        with context.session.begin(subtransactions=True):
++            # goto to the plugin DB and fetch the network
++            network = self._get_network(context, id)
++            if fields and 'status' in fields:
++                # External networks are not backed by nvp lswitches
++                if not network.external:
++                    # Perform explicit state synchronization
++                    self._synchronizer.synchronize_network(
++                        context, network)
++            # Don't do field selection here otherwise we won't be able
++            # to add provider networks fields
++            net_result = self._make_network_dict(network)
++            self._extend_network_dict_provider(context, net_result)
++            self._extend_network_qos_queue(context, net_result)
++        return self._fields(net_result, fields)
++
++    def get_networks(self, context, filters=None, fields=None):
++        filters = filters or {}
++        with context.session.begin(subtransactions=True):
++            networks = super(NvpPluginV2, self).get_networks(context, filters)
++            for net in networks:
++                self._extend_network_dict_provider(context, net)
++                self._extend_network_qos_queue(context, net)
++        return [self._fields(network, fields) for network in networks]
++
++    def update_network(self, context, id, network):
++        pnet._raise_if_updates_provider_attributes(network['network'])
++        if network["network"].get("admin_state_up"):
++            if network['network']["admin_state_up"] is False:
++                raise q_exc.NotImplementedError(_("admin_state_up=False "
++                                                  "networks are not "
++                                                  "supported."))
++        with context.session.begin(subtransactions=True):
++            net = super(NvpPluginV2, self).update_network(context, id, network)
++            if psec.PORTSECURITY in network['network']:
++                self._process_network_port_security_update(
++                    context, network['network'], net)
++            if network['network'].get(ext_qos.QUEUE):
++                net[ext_qos.QUEUE] = network['network'][ext_qos.QUEUE]
++                self._delete_network_queue_mapping(context, id)
++                self._process_network_queue_mapping(context, net)
++            self._process_l3_update(context, net, network['network'])
++            self._extend_network_dict_provider(context, net)
++            self._extend_network_qos_queue(context, net)
++        return net
++
++    def get_ports(self, context, filters=None, fields=None):
++        filters = filters or {}
++        with context.session.begin(subtransactions=True):
++            ports = super(NvpPluginV2, self).get_ports(context, filters)
++            for port in ports:
++                self._extend_port_qos_queue(context, port)
++        return [self._fields(port, fields) for port in ports]
++
++    def create_port(self, context, port):
++        # If PORTSECURITY is not the default value ATTR_NOT_SPECIFIED
++        # then we pass the port to the policy engine. The reason why we don't
++        # pass the value to the policy engine when the port is
++        # ATTR_NOT_SPECIFIED is for the case where a port is created on a
++        # shared network that is not owned by the tenant.
++        port_data = port['port']
++        with context.session.begin(subtransactions=True):
++            # First we allocate port in neutron database
++            neutron_db = super(NvpPluginV2, self).create_port(context, port)
++            neutron_port_id = neutron_db['id']
++            # Update fields obtained from neutron db (eg: MAC address)
++            port["port"].update(neutron_db)
++            self.handle_port_metadata_access(context, neutron_db)
++            # port security extension checks
++            (port_security, has_ip) = self._determine_port_security_and_has_ip(
++                context, port_data)
++            port_data[psec.PORTSECURITY] = port_security
++            self._process_port_port_security_create(
++                context, port_data, neutron_db)
++            # allowed address pair checks
++            if attr.is_attr_set(port_data.get(addr_pair.ADDRESS_PAIRS)):
++                if not port_security:
++                    raise addr_pair.AddressPairAndPortSecurityRequired()
++                else:
++                    self._process_create_allowed_address_pairs(
++                        context, neutron_db,
++                        port_data[addr_pair.ADDRESS_PAIRS])
++            else:
++                # remove ATTR_NOT_SPECIFIED
++                port_data[addr_pair.ADDRESS_PAIRS] = None
++
++            # security group extension checks
++            if port_security and has_ip:
++                self._ensure_default_security_group_on_port(context, port)
++            elif attr.is_attr_set(port_data.get(ext_sg.SECURITYGROUPS)):
++                raise psec.PortSecurityAndIPRequiredForSecurityGroups()
++            port_data[ext_sg.SECURITYGROUPS] = (
++                self._get_security_groups_on_port(context, port))
++            self._process_port_create_security_group(
++                context, port_data, port_data[ext_sg.SECURITYGROUPS])
++            # QoS extension checks
++            port_data[ext_qos.QUEUE] = self._check_for_queue_and_create(
++                context, port_data)
++            self._process_port_queue_mapping(context, port_data)
++            if (isinstance(port_data.get(mac_ext.MAC_LEARNING), bool)):
++                self._create_mac_learning_state(context, port_data)
++            elif mac_ext.MAC_LEARNING in port_data:
++                port_data.pop(mac_ext.MAC_LEARNING)
++
++            LOG.debug(_("create_port completed on NVP for tenant "
++                        "%(tenant_id)s: (%(id)s)"), port_data)
++
++            # remove since it will be added in extend based on policy
++            del port_data[ext_qos.QUEUE]
++            self._extend_port_qos_queue(context, port_data)
++            self._process_portbindings_create_and_update(context,
++                                                         port, port_data)
++        # DB Operation is complete, perform NVP operation
++        try:
++            port_data = port['port'].copy()
++            port_create_func = self._port_drivers['create'].get(
++                port_data['device_owner'],
++                self._port_drivers['create']['default'])
++            port_create_func(context, port_data)
++        except q_exc.NotFound:
++            LOG.warning(_("Logical switch for network %s was not "
++                          "found in NVP."), port_data['network_id'])
++            # Put port in error on quantum DB
++            with context.session.begin(subtransactions=True):
++                port = self._get_port(context, neutron_port_id)
++                port_data['status'] = constants.PORT_STATUS_ERROR
++                port['status'] = port_data['status']
++                context.session.add(port)
++        except Exception:
++            # Port must be removed from Quantum DB
++            with excutils.save_and_reraise_exception():
++                LOG.error(_("Unable to create port or set port "
++                            "attachment in NVP."))
++                with context.session.begin(subtransactions=True):
++                    self._delete_port(context, neutron_port_id)
++
++        self.handle_port_dhcp_access(context, port_data, action='create_port')
++        return port_data
++
++    def update_port(self, context, id, port):
++        delete_security_groups = self._check_update_deletes_security_groups(
++            port)
++        has_security_groups = self._check_update_has_security_groups(port)
++        delete_addr_pairs = self._check_update_deletes_allowed_address_pairs(
++            port)
++        has_addr_pairs = self._check_update_has_allowed_address_pairs(port)
++
++        with context.session.begin(subtransactions=True):
++            ret_port = super(NvpPluginV2, self).update_port(
++                context, id, port)
++            # Save current mac learning state to check whether it's
++            # being updated or not
++            old_mac_learning_state = ret_port.get(mac_ext.MAC_LEARNING)
++            # copy values over - except fixed_ips as
++            # they've alreaby been processed
++            port['port'].pop('fixed_ips', None)
++            ret_port.update(port['port'])
++            tenant_id = self._get_tenant_id_for_create(context, ret_port)
++
++            # populate port_security setting
++            if psec.PORTSECURITY not in port['port']:
++                ret_port[psec.PORTSECURITY] = self._get_port_security_binding(
++                    context, id)
++            has_ip = self._ip_on_port(ret_port)
++            # validate port security and allowed address pairs
++            if not ret_port[psec.PORTSECURITY]:
++                #  has address pairs in request
++                if has_addr_pairs:
++                    raise addr_pair.AddressPairAndPortSecurityRequired()
++                elif not delete_addr_pairs:
++                    # check if address pairs are in db
++                    ret_port[addr_pair.ADDRESS_PAIRS] = (
++                        self.get_allowed_address_pairs(context, id))
++                    if ret_port[addr_pair.ADDRESS_PAIRS]:
++                        raise addr_pair.AddressPairAndPortSecurityRequired()
++
++            if (delete_addr_pairs or has_addr_pairs):
++                # delete address pairs and read them in
++                self._delete_allowed_address_pairs(context, id)
++                self._process_create_allowed_address_pairs(
++                    context, ret_port, ret_port[addr_pair.ADDRESS_PAIRS])
++            # checks if security groups were updated adding/modifying
++            # security groups, port security is set and port has ip
++            if not (has_ip and ret_port[psec.PORTSECURITY]):
++                if has_security_groups:
++                    raise psec.PortSecurityAndIPRequiredForSecurityGroups()
++                # Update did not have security groups passed in. Check
++                # that port does not have any security groups already on it.
++                filters = {'port_id': [id]}
++                security_groups = (
++                    super(NvpPluginV2, self)._get_port_security_group_bindings(
++                        context, filters)
++                )
++                if security_groups and not delete_security_groups:
++                    raise psec.PortSecurityPortHasSecurityGroup()
++
++            if (delete_security_groups or has_security_groups):
++                # delete the port binding and read it with the new rules.
++                self._delete_port_security_group_bindings(context, id)
++                sgids = self._get_security_groups_on_port(context, port)
++                self._process_port_create_security_group(context, ret_port,
++                                                         sgids)
++
++            if psec.PORTSECURITY in port['port']:
++                self._process_port_port_security_update(
++                    context, port['port'], ret_port)
++
++            ret_port[ext_qos.QUEUE] = self._check_for_queue_and_create(
++                context, ret_port)
++            # Populate the mac learning attribute
++            new_mac_learning_state = port['port'].get(mac_ext.MAC_LEARNING)
++            if (new_mac_learning_state is not None and
++                old_mac_learning_state != new_mac_learning_state):
++                self._update_mac_learning_state(context, id,
++                                                new_mac_learning_state)
++                ret_port[mac_ext.MAC_LEARNING] = new_mac_learning_state
++            self._delete_port_queue_mapping(context, ret_port['id'])
++            self._process_port_queue_mapping(context, ret_port)
++            LOG.warn(_("Update port request: %s"), port)
++            nvp_port_id = self._nvp_get_port_id(
++                context, self.cluster, ret_port)
++            if nvp_port_id:
++                try:
++                    nvplib.update_port(self.cluster,
++                                       ret_port['network_id'],
++                                       nvp_port_id, id, tenant_id,
++                                       ret_port['name'], ret_port['device_id'],
++                                       ret_port['admin_state_up'],
++                                       ret_port['mac_address'],
++                                       ret_port['fixed_ips'],
++                                       ret_port[psec.PORTSECURITY],
++                                       ret_port[ext_sg.SECURITYGROUPS],
++                                       ret_port[ext_qos.QUEUE],
++                                       ret_port.get(mac_ext.MAC_LEARNING),
++                                       ret_port.get(addr_pair.ADDRESS_PAIRS))
++
++                    # Update the port status from nvp. If we fail here hide it
++                    # since the port was successfully updated but we were not
++                    # able to retrieve the status.
++                    ret_port['status'] = nvplib.get_port_status(
++                        self.cluster, ret_port['network_id'],
++                        nvp_port_id)
++                # FIXME(arosen) improve exception handling.
++                except Exception:
++                    ret_port['status'] = constants.PORT_STATUS_ERROR
++                    LOG.exception(_("Unable to update port id: %s."),
++                                  nvp_port_id)
++
++            # If nvp_port_id is not in database or in nvp put in error state.
++            else:
++                ret_port['status'] = constants.PORT_STATUS_ERROR
++
++            # remove since it will be added in extend based on policy
++            del ret_port[ext_qos.QUEUE]
++            self._extend_port_qos_queue(context, ret_port)
++            self._process_portbindings_create_and_update(context,
++                                                         port['port'],
++                                                         port)
++        return ret_port
++
++    def delete_port(self, context, id, l3_port_check=True,
++                    nw_gw_port_check=True):
++        """Deletes a port on a specified Virtual Network.
++
++        If the port contains a remote interface attachment, the remote
++        interface is first un-plugged and then the port is deleted.
++
++        :returns: None
++        :raises: exception.PortInUse
++        :raises: exception.PortNotFound
++        :raises: exception.NetworkNotFound
++        """
++        # if needed, check to see if this is a port owned by
++        # a l3 router.  If so, we should prevent deletion here
++        if l3_port_check:
++            self.prevent_l3_port_deletion(context, id)
++        neutron_db_port = self.get_port(context, id)
++        # Perform the same check for ports owned by layer-2 gateways
++        if nw_gw_port_check:
++            self.prevent_network_gateway_port_deletion(context,
++                                                       neutron_db_port)
++        port_delete_func = self._port_drivers['delete'].get(
++            neutron_db_port['device_owner'],
++            self._port_drivers['delete']['default'])
++
++        port_delete_func(context, neutron_db_port)
++        self.disassociate_floatingips(context, id)
++        with context.session.begin(subtransactions=True):
++            queue = self._get_port_queue_bindings(context, {'port_id': [id]})
++            # metadata_dhcp_host_route
++            self.handle_port_metadata_access(
++                context, neutron_db_port, is_delete=True)
++            super(NvpPluginV2, self).delete_port(context, id)
++            # Delete qos queue if possible
++            if queue:
++                self.delete_qos_queue(context, queue[0]['queue_id'], False)
++        self.handle_port_dhcp_access(
++            context, neutron_db_port, action='delete_port')
++
++    def get_port(self, context, id, fields=None):
++        with context.session.begin(subtransactions=True):
++            if fields and 'status' in fields:
++                # Perform explicit state synchronization
++                db_port = self._get_port(context, id)
++                self._synchronizer.synchronize_port(
++                    context, db_port)
++                port = self._make_port_dict(db_port, fields)
++            else:
++                port = super(NvpPluginV2, self).get_port(context, id, fields)
++            self._extend_port_qos_queue(context, port)
++        return port
++
++    def get_router(self, context, id, fields=None):
++        if fields and 'status' in fields:
++            db_router = self._get_router(context, id)
++            # Perform explicit state synchronization
++            self._synchronizer.synchronize_router(
++                context, db_router)
++            return self._make_router_dict(db_router, fields)
++        else:
++            return super(NvpPluginV2, self).get_router(context, id, fields)
++
++    def create_router(self, context, router):
++        # NOTE(salvatore-orlando): We completely override this method in
++        # order to be able to use the NVP ID as Neutron ID
++        # TODO(salvatore-orlando): Propose upstream patch for allowing
++        # 3rd parties to specify IDs as we do with l2 plugin
++        r = router['router']
++        has_gw_info = False
++        tenant_id = self._get_tenant_id_for_create(context, r)
++        # default value to set - nvp wants it (even if we don't have it)
++        nexthop = '1.1.1.1'
++        try:
++            # if external gateway info are set, then configure nexthop to
++            # default external gateway
++            if 'external_gateway_info' in r and r.get('external_gateway_info'):
++                has_gw_info = True
++                gw_info = r['external_gateway_info']
++                del r['external_gateway_info']
++                # The following DB read will be performed again when updating
++                # gateway info. This is not great, but still better than
++                # creating NVP router here and updating it later
++                network_id = (gw_info.get('network_id', None) if gw_info
++                              else None)
++                if network_id:
++                    ext_net = self._get_network(context, network_id)
++                    if not ext_net.external:
++                        msg = (_("Network '%s' is not a valid external "
++                                 "network") % network_id)
++                        raise q_exc.BadRequest(resource='router', msg=msg)
++                    if ext_net.subnets:
++                        ext_subnet = ext_net.subnets[0]
++                        nexthop = ext_subnet.gateway_ip
++            distributed = r.get('distributed')
++            lrouter = nvplib.create_lrouter(
++                self.cluster, tenant_id, router['router']['name'], nexthop,
++                distributed=attr.is_attr_set(distributed) and distributed)
++            # Use NVP identfier for Neutron resource
++            r['id'] = lrouter['uuid']
++            # Update 'distributed' with value returned from NVP
++            # This will be useful for setting the value if the API request
++            # did not specify any value for the 'distributed' attribute
++            r['distributed'] = lrouter['distributed']
++        except nvp_exc.NvpInvalidVersion:
++            msg = _("Cannot create a distributed router with the NVP "
++                    "platform currently in execution. Please, try "
++                    "without specifying the 'distributed' attribute.")
++            LOG.exception(msg)
++            raise q_exc.BadRequest(resource='router', msg=msg)
++        except NvpApiClient.NvpApiException:
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Unable to create logical router on NVP Platform"))
++        # Create the port here - and update it later if we have gw_info
++        try:
++            self._create_and_attach_router_port(
++                self.cluster, context, lrouter['uuid'], {'fake_ext_gw': True},
++                "L3GatewayAttachment",
++                self.cluster.default_l3_gw_service_uuid)
++        except nvp_exc.NvpPluginException:
++            LOG.exception(_("Unable to create L3GW port on logical router  "
++                            "%(router_uuid)s. Verify Default Layer-3 Gateway "
++                            "service %(def_l3_gw_svc)s id is correct") %
++                          {'router_uuid': lrouter['uuid'],
++                           'def_l3_gw_svc':
++                           self.cluster.default_l3_gw_service_uuid})
++            # Try and remove logical router from NVP
++            nvplib.delete_lrouter(self.cluster, lrouter['uuid'])
++            # Return user a 500 with an apter message
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Unable to create router %s") % r['name'])
++
++        with context.session.begin(subtransactions=True):
++            # Transaction nesting is needed to avoid foreign key violations
++            # when processing the service provider binding
++            with context.session.begin(subtransactions=True):
++                router_db = l3_db.Router(id=lrouter['uuid'],
++                                         tenant_id=tenant_id,
++                                         name=r['name'],
++                                         admin_state_up=r['admin_state_up'],
++                                         status="ACTIVE")
++                self._process_distributed_router_create(context, router_db, r)
++                context.session.add(router_db)
++            if has_gw_info:
++                self._update_router_gw_info(context, router_db, gw_info)
++        return self._make_router_dict(router_db)
++
++    def update_router(self, context, router_id, router):
++        # Either nexthop is updated or should be kept as it was before
++        r = router['router']
++        nexthop = None
++        if 'external_gateway_info' in r and r.get('external_gateway_info'):
++            gw_info = r['external_gateway_info']
++            # The following DB read will be performed again when updating
++            # gateway info. This is not great, but still better than
++            # creating NVP router here and updating it later
++            network_id = (gw_info.get('network_id', None) if gw_info
++                          else None)
++            if network_id:
++                ext_net = self._get_network(context, network_id)
++                if not ext_net.external:
++                    msg = (_("Network '%s' is not a valid external "
++                             "network") % network_id)
++                    raise q_exc.BadRequest(resource='router', msg=msg)
++                if ext_net.subnets:
++                    ext_subnet = ext_net.subnets[0]
++                    nexthop = ext_subnet.gateway_ip
++        try:
++            for route in r.get('routes', []):
++                if route['destination'] == '0.0.0.0/0':
++                    msg = _("'routes' cannot contain route '0.0.0.0/0', "
++                            "this must be updated through the default "
++                            "gateway attribute")
++                    raise q_exc.BadRequest(resource='router', msg=msg)
++            previous_routes = nvplib.update_lrouter(
++                self.cluster, router_id, r.get('name'),
++                nexthop, routes=r.get('routes'))
++        # NOTE(salv-orlando): The exception handling below is not correct, but
++        # unfortunately nvplib raises a neutron notfound exception when an
++        # object is not found in the underlying backend
++        except q_exc.NotFound:
++            # Put the router in ERROR status
++            with context.session.begin(subtransactions=True):
++                router_db = self._get_router(context, router_id)
++                router_db['status'] = constants.NET_STATUS_ERROR
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Logical router %s not found "
++                          "on NVP Platform") % router_id)
++        except NvpApiClient.NvpApiException:
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Unable to update logical router on NVP Platform"))
++        except nvp_exc.NvpInvalidVersion:
++            msg = _("Request cannot contain 'routes' with the NVP "
++                    "platform currently in execution. Please, try "
++                    "without specifying the static routes.")
++            LOG.exception(msg)
++            raise q_exc.BadRequest(resource='router', msg=msg)
++        try:
++            return super(NvpPluginV2, self).update_router(context,
++                                                          router_id, router)
++        except (extraroute.InvalidRoutes,
++                extraroute.RouterInterfaceInUseByRoute,
++                extraroute.RoutesExhausted):
++            with excutils.save_and_reraise_exception():
++                # revert changes made to NVP
++                nvplib.update_explicit_routes_lrouter(
++                    self.cluster, router_id, previous_routes)
++
++    def delete_router(self, context, router_id):
++        with context.session.begin(subtransactions=True):
++            # Ensure metadata access network is detached and destroyed
++            # This will also destroy relevant objects on NVP platform.
++            # NOTE(salvatore-orlando): A failure in this operation will
++            # cause the router delete operation to fail too.
++            self.handle_router_metadata_access(
++                context, router_id, do_create=False)
++            super(NvpPluginV2, self).delete_router(context, router_id)
++            # If removal is successful in Neutron it should be so on
++            # the NVP platform too - otherwise the transaction should
++            # be automatically aborted
++            # TODO(salvatore-orlando): Extend the object models in order to
++            # allow an extra field for storing the cluster information
++            # together with the resource
++            try:
++                nvplib.delete_lrouter(self.cluster, router_id)
++            except q_exc.NotFound:
++                LOG.warning(_("Logical router '%s' not found "
++                              "on NVP Platform") % router_id)
++            except NvpApiClient.NvpApiException:
++                raise nvp_exc.NvpPluginException(
++                    err_msg=(_("Unable to delete logical router '%s'"
++                               "on NVP Platform") % router_id))
++
++    def add_router_interface(self, context, router_id, interface_info):
++        # When adding interface by port_id we need to create the
++        # peer port on the nvp logical router in this routine
++        port_id = interface_info.get('port_id')
++        router_iface_info = super(NvpPluginV2, self).add_router_interface(
++            context, router_id, interface_info)
++        # router_iface_info will always have a subnet_id attribute
++        subnet_id = router_iface_info['subnet_id']
++        if port_id:
++            port_data = self._get_port(context, port_id)
++            nvp_port_id = self._nvp_get_port_id(
++                context, self.cluster, port_data)
++            # Fetch lswitch port from NVP in order to retrieve LS uuid
++            # this is necessary as in the case of bridged networks
++            # ls_uuid may be different from network id
++            # TODO(salv-orlando): avoid this NVP round trip by storing
++            # lswitch uuid together with lport uuid mapping.
++            nvp_port = nvplib.query_lswitch_lports(
++                self.cluster, '*',
++                filters={'uuid': nvp_port_id},
++                relations='LogicalSwitchConfig')[0]
++
++            ls_uuid = nvp_port['_relations']['LogicalSwitchConfig']['uuid']
++            # Unplug current attachment from lswitch port
++            nvplib.plug_interface(self.cluster, ls_uuid,
++                                  nvp_port_id, "NoAttachment")
++            # Create logical router port and plug patch attachment
++            self._create_and_attach_router_port(
++                self.cluster, context, router_id, port_data,
++                "PatchAttachment", nvp_port_id, subnet_ids=[subnet_id])
++        subnet = self._get_subnet(context, subnet_id)
++        # If there is an external gateway we need to configure the SNAT rule.
++        # Fetch router from DB
++        router = self._get_router(context, router_id)
++        gw_port = router.gw_port
++        if gw_port and router.enable_snat:
++            # There is a change gw_port might have multiple IPs
++            # In that case we will consider only the first one
++            if gw_port.get('fixed_ips'):
++                snat_ip = gw_port['fixed_ips'][0]['ip_address']
++                cidr_prefix = int(subnet['cidr'].split('/')[1])
++                nvplib.create_lrouter_snat_rule(
++                    self.cluster, router_id, snat_ip, snat_ip,
++                    order=NVP_EXTGW_NAT_RULES_ORDER - cidr_prefix,
++                    match_criteria={'source_ip_addresses': subnet['cidr']})
++        nvplib.create_lrouter_nosnat_rule(
++            self.cluster, router_id,
++            order=NVP_NOSNAT_RULES_ORDER,
++            match_criteria={'destination_ip_addresses': subnet['cidr']})
++
++        # Ensure the NVP logical router has a connection to a 'metadata access'
++        # network (with a proxy listening on its DHCP port), by creating it
++        # if needed.
++        self.handle_router_metadata_access(context, router_id)
++        LOG.debug(_("Add_router_interface completed for subnet:%(subnet_id)s "
++                    "and router:%(router_id)s"),
++                  {'subnet_id': subnet_id, 'router_id': router_id})
++        return router_iface_info
++
++    def remove_router_interface(self, context, router_id, interface_info):
++        # The code below is duplicated from base class, but comes handy
++        # as we need to retrieve the router port id before removing the port
++        subnet = None
++        subnet_id = None
++        if 'port_id' in interface_info:
++            port_id = interface_info['port_id']
++            # find subnet_id - it is need for removing the SNAT rule
++            port = self._get_port(context, port_id)
++            if port.get('fixed_ips'):
++                subnet_id = port['fixed_ips'][0]['subnet_id']
++            if not (port['device_owner'] == l3_db.DEVICE_OWNER_ROUTER_INTF and
++                    port['device_id'] == router_id):
++                raise l3.RouterInterfaceNotFound(router_id=router_id,
++                                                 port_id=port_id)
++        elif 'subnet_id' in interface_info:
++            subnet_id = interface_info['subnet_id']
++            subnet = self._get_subnet(context, subnet_id)
++            rport_qry = context.session.query(models_v2.Port)
++            ports = rport_qry.filter_by(
++                device_id=router_id,
++                device_owner=l3_db.DEVICE_OWNER_ROUTER_INTF,
++                network_id=subnet['network_id'])
++            for p in ports:
++                if p['fixed_ips'][0]['subnet_id'] == subnet_id:
++                    port_id = p['id']
++                    break
++            else:
++                raise l3.RouterInterfaceNotFoundForSubnet(router_id=router_id,
++                                                          subnet_id=subnet_id)
++        # Finally remove the data from the Neutron DB
++        # This will also destroy the port on the logical switch
++        info = super(NvpPluginV2, self).remove_router_interface(
++            context, router_id, interface_info)
++
++        # Ensure the connection to the 'metadata access network'
++        # is removed  (with the network) if this the last subnet
++        # on the router
++        self.handle_router_metadata_access(context, router_id)
++        try:
++            if not subnet:
++                subnet = self._get_subnet(context, subnet_id)
++            router = self._get_router(context, router_id)
++            # Remove SNAT rule if external gateway is configured
++            if router.gw_port:
++                nvplib.delete_nat_rules_by_match(
++                    self.cluster, router_id, "SourceNatRule",
++                    max_num_expected=1, min_num_expected=1,
++                    source_ip_addresses=subnet['cidr'])
++            # Relax the minimum expected number as the nosnat rules
++            # do not exist in 2.x deployments
++            nvplib.delete_nat_rules_by_match(
++                self.cluster, router_id, "NoSourceNatRule",
++                max_num_expected=1, min_num_expected=0,
++                destination_ip_addresses=subnet['cidr'])
++        except NvpApiClient.ResourceNotFound:
++            raise nvp_exc.NvpPluginException(
++                err_msg=(_("Logical router resource %s not found "
++                           "on NVP platform") % router_id))
++        except NvpApiClient.NvpApiException:
++            raise nvp_exc.NvpPluginException(
++                err_msg=(_("Unable to update logical router"
++                           "on NVP Platform")))
++        return info
++
++    def _retrieve_and_delete_nat_rules(self, floating_ip_address,
++                                       internal_ip, router_id,
++                                       min_num_rules_expected=0):
++        try:
++            nvplib.delete_nat_rules_by_match(
++                self.cluster, router_id, "DestinationNatRule",
++                max_num_expected=1,
++                min_num_expected=min_num_rules_expected,
++                destination_ip_addresses=floating_ip_address)
++
++            # Remove SNAT rule associated with the single fixed_ip
++            # to floating ip
++            nvplib.delete_nat_rules_by_match(
++                self.cluster, router_id, "SourceNatRule",
++                max_num_expected=1,
++                min_num_expected=min_num_rules_expected,
++                source_ip_addresses=internal_ip)
++        except NvpApiClient.NvpApiException:
++            LOG.exception(_("An error occurred while removing NAT rules "
++                            "on the NVP platform for floating ip:%s"),
++                          floating_ip_address)
++            raise
++        except nvp_exc.NvpNatRuleMismatch:
++            # Do not surface to the user
++            LOG.warning(_("An incorrect number of matching NAT rules "
++                          "was found on the NVP platform"))
++
++    def _remove_floatingip_address(self, context, fip_db):
++        # Remove floating IP address from logical router port
++        # Fetch logical port of router's external gateway
++        router_id = fip_db.router_id
++        nvp_gw_port_id = nvplib.find_router_gw_port(
++            context, self.cluster, router_id)['uuid']
++        ext_neutron_port_db = self._get_port(context.elevated(),
++                                             fip_db.floating_port_id)
++        nvp_floating_ips = self._build_ip_address_list(
++            context.elevated(), ext_neutron_port_db['fixed_ips'])
++        nvplib.update_lrouter_port_ips(self.cluster,
++                                       router_id,
++                                       nvp_gw_port_id,
++                                       ips_to_add=[],
++                                       ips_to_remove=nvp_floating_ips)
++
++    def _update_fip_assoc(self, context, fip, floatingip_db, external_port):
++        """Update floating IP association data.
++
++        Overrides method from base class.
++        The method is augmented for creating NAT rules in the process.
++        """
++        if (('fixed_ip_address' in fip and fip['fixed_ip_address']) and
++            not ('port_id' in fip and fip['port_id'])):
++            msg = _("fixed_ip_address cannot be specified without a port_id")
++            raise q_exc.BadRequest(resource='floatingip', msg=msg)
++        port_id = internal_ip = router_id = None
++        if 'port_id' in fip and fip['port_id']:
++            port_qry = context.session.query(l3_db.FloatingIP)
++            try:
++                port_qry.filter_by(fixed_port_id=fip['port_id']).one()
++                raise l3.FloatingIPPortAlreadyAssociated(
++                    port_id=fip['port_id'],
++                    fip_id=floatingip_db['id'],
++                    floating_ip_address=floatingip_db['floating_ip_address'],
++                    fixed_ip=floatingip_db['fixed_ip_address'],
++                    net_id=floatingip_db['floating_network_id'])
++            except sa_exc.NoResultFound:
++                pass
++            port_id, internal_ip, router_id = self.get_assoc_data(
++                context,
++                fip,
++                floatingip_db['floating_network_id'])
++
++        floating_ip = floatingip_db['floating_ip_address']
++        # Retrieve and delete existing NAT rules, if any
++        if not router_id and floatingip_db.get('fixed_port_id'):
++            # This happens if we're disassociating. Need to explicitly
++            # find the router serving this floating IP
++            tmp_fip = fip.copy()
++            tmp_fip['port_id'] = floatingip_db['fixed_port_id']
++            _pid, internal_ip, router_id = self.get_assoc_data(
++                context, tmp_fip, floatingip_db['floating_network_id'])
++        # If there's no association router_id will be None
++        if router_id:
++            self._retrieve_and_delete_nat_rules(floating_ip,
++                                                internal_ip,
++                                                router_id)
++            # Fetch logical port of router's external gateway
++            nvp_gw_port_id = nvplib.find_router_gw_port(
++                context, self.cluster, router_id)['uuid']
++            nvp_floating_ips = self._build_ip_address_list(
++                context.elevated(), external_port['fixed_ips'])
++            LOG.debug(_("Address list for NVP logical router "
++                        "port:%s"), nvp_floating_ips)
++            # Re-create NAT rules only if a port id is specified
++            if 'port_id' in fip and fip['port_id']:
++                try:
++                    # Create new NAT rules
++                    nvplib.create_lrouter_dnat_rule(
++                        self.cluster, router_id, internal_ip,
++                        order=NVP_FLOATINGIP_NAT_RULES_ORDER,
++                        match_criteria={'destination_ip_addresses':
++                                        floating_ip})
++                    # setup snat rule such that src ip of a IP packet when
++                    # using floating is the floating ip itself.
++                    nvplib.create_lrouter_snat_rule(
++                        self.cluster, router_id, floating_ip, floating_ip,
++                        order=NVP_FLOATINGIP_NAT_RULES_ORDER,
++                        match_criteria={'source_ip_addresses': internal_ip})
++                    # Add Floating IP address to router_port
++                    nvplib.update_lrouter_port_ips(self.cluster,
++                                                   router_id,
++                                                   nvp_gw_port_id,
++                                                   ips_to_add=nvp_floating_ips,
++                                                   ips_to_remove=[])
++                except NvpApiClient.NvpApiException:
++                    LOG.exception(_("An error occurred while creating NAT "
++                                    "rules on the NVP platform for floating "
++                                    "ip:%(floating_ip)s mapped to "
++                                    "internal ip:%(internal_ip)s"),
++                                  {'floating_ip': floating_ip,
++                                   'internal_ip': internal_ip})
++                    raise nvp_exc.NvpPluginException(err_msg=msg)
++            elif floatingip_db['fixed_port_id']:
++                # This is a disassociation.
++                # Remove floating IP address from logical router port
++                internal_ip = None
++                nvplib.update_lrouter_port_ips(self.cluster,
++                                               router_id,
++                                               nvp_gw_port_id,
++                                               ips_to_add=[],
++                                               ips_to_remove=nvp_floating_ips)
++
++        floatingip_db.update({'fixed_ip_address': internal_ip,
++                              'fixed_port_id': port_id,
++                              'router_id': router_id})
++
++    def delete_floatingip(self, context, id):
++        fip_db = self._get_floatingip(context, id)
++        # Check whether the floating ip is associated or not
++        if fip_db.fixed_port_id:
++            self._retrieve_and_delete_nat_rules(fip_db.floating_ip_address,
++                                                fip_db.fixed_ip_address,
++                                                fip_db.router_id,
++                                                min_num_rules_expected=1)
++            # Remove floating IP address from logical router port
++            self._remove_floatingip_address(context, fip_db)
++        return super(NvpPluginV2, self).delete_floatingip(context, id)
++
++    def disassociate_floatingips(self, context, port_id):
++        try:
++            fip_qry = context.session.query(l3_db.FloatingIP)
++            fip_db = fip_qry.filter_by(fixed_port_id=port_id).one()
++            self._retrieve_and_delete_nat_rules(fip_db.floating_ip_address,
++                                                fip_db.fixed_ip_address,
++                                                fip_db.router_id,
++                                                min_num_rules_expected=1)
++            self._remove_floatingip_address(context, fip_db)
++        except sa_exc.NoResultFound:
++            LOG.debug(_("The port '%s' is not associated with floating IPs"),
++                      port_id)
++        except q_exc.NotFound:
++            LOG.warning(_("Nat rules not found in nvp for port: %s"), id)
++
++        super(NvpPluginV2, self).disassociate_floatingips(context, port_id)
++
++    def create_network_gateway(self, context, network_gateway):
++        """Create a layer-2 network gateway.
++
++        Create the gateway service on NVP platform and corresponding data
++        structures in Neutron datase.
++        """
++        # Ensure the default gateway in the config file is in sync with the db
++        self._ensure_default_network_gateway()
++        # Need to re-do authZ checks here in order to avoid creation on NVP
++        gw_data = network_gateway[networkgw.RESOURCE_NAME.replace('-', '_')]
++        tenant_id = self._get_tenant_id_for_create(context, gw_data)
++        devices = gw_data['devices']
++        # Populate default physical network where not specified
++        for device in devices:
++            if not device.get('interface_name'):
++                device['interface_name'] = self.cluster.default_interface_name
++        try:
++            nvp_res = nvplib.create_l2_gw_service(self.cluster, tenant_id,
++                                                  gw_data['name'], devices)
++            nvp_uuid = nvp_res.get('uuid')
++        except Exception:
++            raise nvp_exc.NvpPluginException(
++                err_msg=_("Create_l2_gw_service did not "
++                          "return an uuid for the newly "
++                          "created resource:%s") % nvp_res)
++        gw_data['id'] = nvp_uuid
++        return super(NvpPluginV2, self).create_network_gateway(context,
++                                                               network_gateway)
++
++    def delete_network_gateway(self, context, id):
++        """Remove a layer-2 network gateway.
++
++        Remove the gateway service from NVP platform and corresponding data
++        structures in Neutron datase.
++        """
++        # Ensure the default gateway in the config file is in sync with the db
++        self._ensure_default_network_gateway()
++        with context.session.begin(subtransactions=True):
++            try:
++                super(NvpPluginV2, self).delete_network_gateway(context, id)
++                nvplib.delete_l2_gw_service(self.cluster, id)
++            except NvpApiClient.ResourceNotFound:
++                # Do not cause a 500 to be returned to the user if
++                # the corresponding NVP resource does not exist
++                LOG.exception(_("Unable to remove gateway service from "
++                                "NVP plaform - the resource was not found"))
++
++    def get_network_gateway(self, context, id, fields=None):
++        # Ensure the default gateway in the config file is in sync with the db
++        self._ensure_default_network_gateway()
++        return super(NvpPluginV2, self).get_network_gateway(context,
++                                                            id, fields)
++
++    def get_network_gateways(self, context, filters=None, fields=None):
++        # Ensure the default gateway in the config file is in sync with the db
++        self._ensure_default_network_gateway()
++        # Ensure the tenant_id attribute is populated on returned gateways
++        net_gateways = super(NvpPluginV2,
++                             self).get_network_gateways(context,
++                                                        filters,
++                                                        fields)
++        return net_gateways
++
++    def update_network_gateway(self, context, id, network_gateway):
++        # Ensure the default gateway in the config file is in sync with the db
++        self._ensure_default_network_gateway()
++        return super(NvpPluginV2, self).update_network_gateway(
++            context, id, network_gateway)
++
++    def connect_network(self, context, network_gateway_id,
++                        network_mapping_info):
++        # Ensure the default gateway in the config file is in sync with the db
++        self._ensure_default_network_gateway()
++        return super(NvpPluginV2, self).connect_network(
++            context, network_gateway_id, network_mapping_info)
++
++    def disconnect_network(self, context, network_gateway_id,
++                           network_mapping_info):
++        # Ensure the default gateway in the config file is in sync with the db
++        self._ensure_default_network_gateway()
++        return super(NvpPluginV2, self).disconnect_network(
++            context, network_gateway_id, network_mapping_info)
++
++    def create_security_group(self, context, security_group, default_sg=False):
++        """Create security group.
++
++        If default_sg is true that means a we are creating a default security
++        group and we don't need to check if one exists.
++        """
++        s = security_group.get('security_group')
++
++        tenant_id = self._get_tenant_id_for_create(context, s)
++        if not default_sg:
++            self._ensure_default_security_group(context, tenant_id)
++
++        nvp_secgroup = nvplib.create_security_profile(self.cluster,
++                                                      tenant_id, s)
++        security_group['security_group']['id'] = nvp_secgroup['uuid']
++        return super(NvpPluginV2, self).create_security_group(
++            context, security_group, default_sg)
++
++    def delete_security_group(self, context, security_group_id):
++        """Delete a security group.
++
++        :param security_group_id: security group rule to remove.
++        """
++        with context.session.begin(subtransactions=True):
++            security_group = super(NvpPluginV2, self).get_security_group(
++                context, security_group_id)
++            if not security_group:
++                raise ext_sg.SecurityGroupNotFound(id=security_group_id)
++
++            if security_group['name'] == 'default' and not context.is_admin:
++                raise ext_sg.SecurityGroupCannotRemoveDefault()
++
++            filters = {'security_group_id': [security_group['id']]}
++            if super(NvpPluginV2, self)._get_port_security_group_bindings(
++                context, filters):
++                raise ext_sg.SecurityGroupInUse(id=security_group['id'])
++            nvplib.delete_security_profile(self.cluster,
++                                           security_group['id'])
++            return super(NvpPluginV2, self).delete_security_group(
++                context, security_group_id)
++
++    def _validate_security_group_rules(self, context, rules):
++        for rule in rules['security_group_rules']:
++            r = rule.get('security_group_rule')
++            port_based_proto = (self._get_ip_proto_number(r['protocol'])
++                                in securitygroups_db.IP_PROTOCOL_MAP.values())
++            if (not port_based_proto and
++                (r['port_range_min'] is not None or
++                r['port_range_max'] is not None)):
++                msg = (_("Port values not valid for "
++                         "protocol: %s") % r['protocol'])
++                raise q_exc.BadRequest(resource='security_group_rule',
++                                       msg=msg)
++        return super(NvpPluginV2, self)._validate_security_group_rules(context,
++                                                                       rules)
++
++    def create_security_group_rule(self, context, security_group_rule):
++        """Create a single security group rule."""
++        bulk_rule = {'security_group_rules': [security_group_rule]}
++        return self.create_security_group_rule_bulk(context, bulk_rule)[0]
++
++    def create_security_group_rule_bulk(self, context, security_group_rule):
++        """Create security group rules.
++
++        :param security_group_rule: list of rules to create
++        """
++        s = security_group_rule.get('security_group_rules')
++        tenant_id = self._get_tenant_id_for_create(context, s)
++
++        # TODO(arosen) is there anyway we could avoid having the update of
++        # the security group rules in nvp outside of this transaction?
++        with context.session.begin(subtransactions=True):
++            self._ensure_default_security_group(context, tenant_id)
++            security_group_id = self._validate_security_group_rules(
++                context, security_group_rule)
++
++            # Check to make sure security group exists
++            security_group = super(NvpPluginV2, self).get_security_group(
++                context, security_group_id)
++
++            if not security_group:
++                raise ext_sg.SecurityGroupNotFound(id=security_group_id)
++            # Check for duplicate rules
++            self._check_for_duplicate_rules(context, s)
++            # gather all the existing security group rules since we need all
++            # of them to PUT to NVP.
++            combined_rules = self._merge_security_group_rules_with_current(
++                context, s, security_group['id'])
++            nvplib.update_security_group_rules(self.cluster,
++                                               security_group['id'],
++                                               combined_rules)
++            return super(
++                NvpPluginV2, self).create_security_group_rule_bulk_native(
++                    context, security_group_rule)
++
++    def delete_security_group_rule(self, context, sgrid):
++        """Delete a security group rule
++        :param sgrid: security group id to remove.
++        """
++        with context.session.begin(subtransactions=True):
++            # determine security profile id
++            security_group_rule = (
++                super(NvpPluginV2, self).get_security_group_rule(
++                    context, sgrid))
++            if not security_group_rule:
++                raise ext_sg.SecurityGroupRuleNotFound(id=sgrid)
++
++            sgid = security_group_rule['security_group_id']
++            current_rules = self._get_security_group_rules_nvp_format(
++                context, sgid, True)
++
++            self._remove_security_group_with_id_and_id_field(
++                current_rules, sgrid)
++            nvplib.update_security_group_rules(
++                self.cluster, sgid, current_rules)
++            return super(NvpPluginV2, self).delete_security_group_rule(context,
++                                                                       sgrid)
++
++    def create_qos_queue(self, context, qos_queue, check_policy=True):
++        q = qos_queue.get('qos_queue')
++        self._validate_qos_queue(context, q)
++        q['id'] = nvplib.create_lqueue(self.cluster,
++                                       self._nvp_lqueue(q))
++        return super(NvpPluginV2, self).create_qos_queue(context, qos_queue)
++
++    def delete_qos_queue(self, context, id, raise_in_use=True):
++        filters = {'queue_id': [id]}
++        queues = self._get_port_queue_bindings(context, filters)
++        if queues:
++            if raise_in_use:
++                raise ext_qos.QueueInUseByPort()
++            else:
++                return
++        nvplib.delete_lqueue(self.cluster, id)
++        return super(NvpPluginV2, self).delete_qos_queue(context, id)
+diff --git a/neutron/tests/unit/test_l3_agent.py b/neutron/tests/unit/test_l3_agent.py
+index 8f936d4..645566d 100644
+--- a/neutron/tests/unit/test_l3_agent.py
++++ b/neutron/tests/unit/test_l3_agent.py
+@@ -158,8 +158,8 @@ class TestBasicRouterOperations(base.BaseTestCase):
+         agent = l3_agent.L3NATAgent(HOSTNAME, self.conf)
+         internal_cidrs = ['100.0.1.0/24', '200.74.0.0/16']
+         ex_gw_port = {'fixed_ips': [{'ip_address': '20.0.0.30',
+-                                     'subnet_id': _uuid()}],
+-                      'subnet': {'gateway_ip': '20.0.0.1'},
++                                     'subnet_id': _uuid(),
++                                     'subnet': {'gateway_ip': '20.0.0.1'}}],
+                       'id': _uuid(),
+                       'network_id': _uuid(),
+                       'mac_address': 'ca:fe:de:ad:be:ef',
+diff --git a/neutron/tests/unit/test_l3_plugin.py b/neutron/tests/unit/test_l3_plugin.py
+index be5b177..586c3fa 100644
+--- a/neutron/tests/unit/test_l3_plugin.py
++++ b/neutron/tests/unit/test_l3_plugin.py
+@@ -641,7 +641,7 @@ class L3NatTestCaseBase(L3NatTestCaseMixin):
+                 # fetch port and confirm device_id
+                 r_port_id = body['port_id']
+                 body = self._show('ports', r_port_id)
+-                self.assertEqual(body['port']['device_id'], r['router']['id'])
++                self.assertEqual(body['port']['device_id'], '')
+ 
+                 body = self._router_interface_action('remove',
+                                                      r['router']['id'],
+@@ -650,9 +650,11 @@ class L3NatTestCaseBase(L3NatTestCaseMixin):
+                 body = self._show('ports', r_port_id,
+                                   expected_code=exc.HTTPNotFound.code)
+ 
++                self.assertEqual(len(test_notifier.NOTIFICATIONS), 8)
+                 self.assertEqual(
+-                    set(exp_notifications),
+-                    set(n['event_type'] for n in test_notifier.NOTIFICATIONS))
++                    exp_notifications,
++                    [n['event_type'] for n in test_notifier.NOTIFICATIONS]
++                )
+ 
+                 for n in test_notifier.NOTIFICATIONS:
+                     if n['event_type'].startswith('router.interface.'):
+@@ -665,6 +667,81 @@ class L3NatTestCaseBase(L3NatTestCaseMixin):
+                         # nsx metadata access case
+                         self.assertIn(payload['tenant_id'], [stid, ''])
+ 
++    def test_router_add_interface_subnet_from_same_network(self):
++        exp_notifications = ['router.create.start',
++                             'router.create.end',
++                             'network.create.start',
++                             'network.create.end',
++                             'subnet.create.start',
++                             'subnet.create.end',
++                             'subnet.create.start',
++                             'subnet.create.end',
++                             'router.interface.create',
++                             'router.interface.create',
++                             'router.interface.delete',
++                             'router.interface.delete']
++        test_notifier.NOTIFICATIONS = []
++        with self.router() as r:
++            with self.network() as net:
++                with contextlib.nested(
++                    self.subnet(network=net, cidr='10.0.0.0/24'),
++                    self.subnet(network=net, cidr='10.1.0.0/24')) as (s1, s2):
++                    body = self._router_interface_action('add',
++                                                         r['router']['id'],
++                                                         s1['subnet']['id'],
++                                                         None)
++                    self.assertIn('port_id', body)
++                    r_port_id = body['port_id']
++
++                    # add subnet from same net, should reuse port
++                    body = self._router_interface_action('add',
++                                                         r['router']['id'],
++                                                         s2['subnet']['id'],
++                                                         None)
++                    self.assertIn('port_id', body)
++                    self.assertEqual(body['port_id'], r_port_id)
++                    body = self._show('ports', r_port_id)
++
++                    self.assertEqual(len(body['port']['fixed_ips']), 2)
++
++                    body = self._router_interface_action('remove',
++                                                         r['router']['id'],
++                                                         s1['subnet']['id'],
++                                                         None)
++                    body = self._show('ports', r_port_id)
++
++                    self.assertEqual(
++                        body['port']['fixed_ips'],
++                        [
++                            {
++                                'subnet_id': s2['subnet']['id'],
++                                'ip_address': s2['subnet']['gateway_ip']
++                            }
++                        ]
++                    )
++
++                    body = self._router_interface_action('remove',
++                                                         r['router']['id'],
++                                                         s2['subnet']['id'],
++                                                         None)
++
++                    self.assertEqual(len(test_notifier.NOTIFICATIONS), 12)
++                    self.assertEqual(
++                        exp_notifications,
++                        [n['event_type'] for n in test_notifier.NOTIFICATIONS]
++                    )
++
++                    for n in test_notifier.NOTIFICATIONS:
++                        if n['event_type'].startswith('router.interface.'):
++                            payload = n['payload']['router.interface']
++                            self.assertIn('id', payload)
++                            self.assertEqual(payload['id'], r['router']['id'])
++                            self.assertIn('tenant_id', payload)
++                            stid = s1['subnet']['tenant_id']
++                            # tolerate subnet tenant deliberately to '' in the
++                            # nicira metadata access case
++                            self.assertIn(payload['tenant_id'], [stid, ''])
++
+     def test_router_add_interface_subnet_with_bad_tenant_returns_404(self):
+         with mock.patch('neutron.context.Context.to_dict') as tdict:
+             tenant_id = _uuid()
+@@ -747,7 +824,7 @@ class L3NatTestCaseBase(L3NatTestCaseMixin):
+ 
+                 # fetch port and confirm device_id
+                 body = self._show('ports', p['port']['id'])
+-                self.assertEqual(body['port']['device_id'], r['router']['id'])
++                self.assertEqual(body['port']['device_id'], '')
+ 
+                 # clean-up
+                 self._router_interface_action('remove',
+@@ -1659,11 +1736,11 @@ class L3NatTestCaseBase(L3NatTestCaseMixin):
+ 
+     def test_floatingip_delete_router_intf_with_subnet_id_returns_409(self):
+         found = False
+-        with self.floatingip_with_assoc():
++        with self.floatingip_with_assoc() as fip:
+             for p in self._list('ports')['ports']:
+                 if p['device_owner'] == l3_constants.DEVICE_OWNER_ROUTER_INTF:
+                     subnet_id = p['fixed_ips'][0]['subnet_id']
+-                    router_id = p['device_id']
++                    router_id = fip['floatingip']['router_id']
+                     self._router_interface_action(
+                         'remove', router_id, subnet_id, None,
+                         expected_code=exc.HTTPConflict.code)
+@@ -1673,10 +1750,10 @@ class L3NatTestCaseBase(L3NatTestCaseMixin):
+ 
+     def test_floatingip_delete_router_intf_with_port_id_returns_409(self):
+         found = False
+-        with self.floatingip_with_assoc():
++        with self.floatingip_with_assoc() as fip:
+             for p in self._list('ports')['ports']:
+-                if p['device_owner'] == l3_constants.DEVICE_OWNER_ROUTER_INTF:
+-                    router_id = p['device_id']
++                if p['device_owner'] == 'network:router_interface':
++                    router_id = fip['floatingip']['router_id']
+                     self._router_interface_action(
+                         'remove', router_id, None, p['id'],
+                         expected_code=exc.HTTPConflict.code)
+@@ -1718,7 +1795,7 @@ class L3AgentDbTestCaseBase(L3NatTestCaseMixin):
+                 self.assertEqual(1, len(routers))
+                 interfaces = routers[0][l3_constants.INTERFACE_KEY]
+                 self.assertEqual(1, len(interfaces))
+-                subnet_id = interfaces[0]['subnet']['id']
++                subnet_id = interfaces[0]['fixed_ips'][0]['subnet']['id']
+                 wanted_subnetid = p['port']['fixed_ips'][0]['subnet_id']
+                 self.assertEqual(wanted_subnetid, subnet_id)
+                 # clean-up
+@@ -1727,7 +1804,7 @@ class L3AgentDbTestCaseBase(L3NatTestCaseMixin):
+                                               None,
+                                               p['port']['id'])
+ 
+-    def test_l3_agent_routers_query_ignore_interfaces_with_moreThanOneIp(self):
++    def test_l3_agent_routers_query_ignore_intf_with_more_than_one_ip(self):
+         with self.router() as r:
+             with self.subnet(cidr='9.0.1.0/24') as subnet:
+                 with self.port(subnet=subnet,
+@@ -1765,7 +1842,8 @@ class L3AgentDbTestCaseBase(L3NatTestCaseMixin):
+                     context.get_admin_context(), [r['router']['id']])
+                 self.assertEqual(1, len(routers))
+                 gw_port = routers[0]['gw_port']
+-                self.assertEqual(s['subnet']['id'], gw_port['subnet']['id'])
++                self.assertEqual(s['subnet']['id'],
++                                 gw_port['fixed_ips'][0]['subnet_id'])
+                 self._remove_external_gateway_from_router(
+                     r['router']['id'],
+                     s['subnet']['network_id'])
+-- 
+1.9.3 (Apple Git-50)
+

--- a/patches/utils
+++ b/patches/utils
@@ -10,13 +10,17 @@ function patch_neutron() {
     PATCH_HASH="$(cat $PATCHES_FOLDER/remove_lazy_join_from_ipallocationpools.patch | md5sum | awk '{ print $1 }')"
     # Apply the patch just first time we stack
     if [ "$LAST_COMMIT_HASH" != "$PATCH_HASH" ]; then
-        git fetch https://review.openstack.org/openstack/neutron refs/changes/48/17248/4 && git cherry-pick FETCH_HEAD || true
+        # This is the bulk of the implemtation for the L3 RouterPort
+        # relationship implementation.  A large amount of this has actually
+        # been merged into stable/juno, so we won't have to carry this mess
+        # going forward.
+        git apply $PATCHES_FOLDER/l3-router-port-relationship.patch
+        git add .
+        git commit -m "DreamHost: Add routerport instead of overloading device_id(merged with conflicts)"
         # The patch doesn't apply cleanly so we need to apply another patch on top of it to fix conflicts. Have them as
         # separate patches make us able to apply patches just first time we stack  because we can get the hash of
         # 'git diff HEAD^', compare it with the hash of the patch file and undestand if the patch has already been
         # applied or not.
-        git add .
-        git commit -m "DreamHost: Add routerport instead of overloading device_id(merged with conflicts)"
         git apply $PATCHES_FOLDER/add_routerport_instead_of_overloading_device_id.patch
         git add .
         git commit -m "DreamHost: Fix conflicts introduced by previous patch"


### PR DESCRIPTION
Previously, we were cherrypicking this from an abandoned review.openstack.org
patchset (https://review.openstack.org/#/c/17248/).  We should host this
ourselves for icehouse, because we won't need it in stable/juno, and who knows
when the Openstack Infra team will clean up old, abandoned reviews like this
one.