### PR TITLE
Allow services user to boot vms with ports on the public nets

### DIFF
--- a/20-akanda.sh
+++ b/20-akanda.sh
@@ -11,6 +11,7 @@ if [[ "$1" == "source" ]]; then
 
 elif [[ "$1" == "stack" && "$2" == "install" ]]; then
     echo_summary "Installing Akanda"
+    set_neutron_user_permission
     install_akanda
 
 elif [[ "$1" == "stack" && "$2" == "post-config" ]]; then

--- a/akanda
+++ b/akanda
@@ -179,3 +179,15 @@ function stop_akanda_rug() {
     screen_stop_service ak-rug
     stop_process ak-rug
 }
+
+function set_neutron_user_permission() {
+    # Starting from juno services users are not granted with the admin role anymore
+    # but with a new `service` role.
+    # Since nova policy allows only vms booted by admin users to attach ports on the
+    # public networks, we need to modify the policy and allow users with the service
+    # to do that too.
+
+    local old_value='"network:attach_external_network": "rule:admin_api"'
+    local new_value='"network:attach_external_network": "rule:admin_api or role:service"'
+    sed -i "s/$old_value/$new_value/g" /etc/nova/policy.json
+}


### PR DESCRIPTION
Starting from juno services users are not granted with the admin
role anymore but with a new `service` role.
Since nova policy allows only vms booted by admin users to attach
ports on the public networks, we need to modify the policy and
allow users with the service to do that too.

Change-Id: I21506b9dadc689dfec5e5fe776746503cecc4c97
Signed-off-by: Rosario Di Somma <rosario.disomma@dreamhost.com>