### PR TITLE
Fix routerports migration for installations that used akanda , pre juno

### DIFF
--- a/patches/fix_routerports_migration.patch
+++ b/patches/fix_routerports_migration.patch
@@ -1,0 +1,58 @@
+diff --git a/neutron/db/migration/alembic_migrations/versions/544673ac99ab_add_router_port_table.py b/neutron/db/migration/alembic_migrations/versions/544673ac99ab_add_router_port_table.py
+index cf3190b..35c0e0e 100644
+--- a/neutron/db/migration/alembic_migrations/versions/544673ac99ab_add_router_port_table.py
++++ b/neutron/db/migration/alembic_migrations/versions/544673ac99ab_add_router_port_table.py
+@@ -28,6 +28,8 @@ down_revision = '1680e1f0c4dc'
+ from alembic import op
+ import sqlalchemy as sa
+ 
++from neutron.db import migration
++
+ SQL_STATEMENT = (
+     "insert into routerports "
+     "select "
+@@ -40,25 +42,26 @@ SQL_STATEMENT = (
+ 
+ 
+ def upgrade():
+-    op.create_table(
+-        'routerports',
+-        sa.Column('router_id', sa.String(length=36), nullable=False),
+-        sa.Column('port_id', sa.String(length=36), nullable=False),
+-        sa.Column('port_type', sa.String(length=255)),
+-        sa.PrimaryKeyConstraint('router_id', 'port_id'),
+-        sa.ForeignKeyConstraint(
+-            ['router_id'],
+-            ['routers.id'],
+-            ondelete='CASCADE'
+-        ),
+-        sa.ForeignKeyConstraint(
+-            ['port_id'],
+-            ['ports.id'],
+-            ondelete='CASCADE'
+-        ),
+-    )
++    if not migration.schema_has_table('routerports'):
++        op.create_table(
++            'routerports',
++            sa.Column('router_id', sa.String(length=36), nullable=False),
++            sa.Column('port_id', sa.String(length=36), nullable=False),
++            sa.Column('port_type', sa.String(length=255)),
++            sa.PrimaryKeyConstraint('router_id', 'port_id'),
++            sa.ForeignKeyConstraint(
++                ['router_id'],
++                ['routers.id'],
++                ondelete='CASCADE'
++            ),
++            sa.ForeignKeyConstraint(
++                ['port_id'],
++                ['ports.id'],
++                ondelete='CASCADE'
++            ),
++        )
+ 
+-    op.execute(SQL_STATEMENT)
++        op.execute(SQL_STATEMENT)
+ 
+ 
+ def downgrade():

--- a/patches/utils
+++ b/patches/utils
@@ -25,5 +25,10 @@ function patch_neutron() {
         git apply $PATCHES_FOLDER/fix_neutron_to_nova_notification.patch
         git add .
         git commit -m "DreamHost: Fix neutron-to-nova notification about ports creation"
+
+        # routerports migration patch
+        git apply $PATCHES_FOLDER/fix_routerports_migration.patch
+        git add .
+        git commit -m "DreamHost: fix routerports migration script"
     fi
 }


### PR DESCRIPTION


This patch will skip routerports migrations if the 'routerports' table already exists.
The only reason you would need this patch is if you were running akanda w/neutron before
the juno release.