### PR TITLE
Remove lazy join from ipallocationpools

### DIFF
--- a/patches/remove_ipallocationpools_lazy_join.patch
+++ b/patches/remove_ipallocationpools_lazy_join.patch
@@ -1,0 +1,12 @@
+diff --git a/neutron/db/models_v2.py b/neutron/db/models_v2.py
+index 53efc66..81e9449 100644
+--- a/neutron/db/models_v2.py
++++ b/neutron/db/models_v2.py
+@@ -78,7 +78,6 @@ class IPAllocationPool(model_base.BASEV2, HasId):
+     last_ip = sa.Column(sa.String(64), nullable=False)
+     available_ranges = orm.relationship(IPAvailabilityRange,
+                                         backref='ipallocationpool',
+-                                        lazy="joined",
+                                         cascade='all, delete-orphan')
+ 
+     def __repr__(self):

--- a/patches/utils
+++ b/patches/utils
@@ -30,5 +30,10 @@ function patch_neutron() {
         git apply $PATCHES_FOLDER/fix_routerports_migration.patch
         git add .
         git commit -m "DreamHost: fix routerports migration script"
+
+        # remove ipallocationpools lazy join
+        git apply $PATCHES_FOLDER/remove_ipallocationpools_lazy_join.patch
+        git add .
+        git commit -m "DreamHost: remove ipallocationpools lazy join"
     fi
 }


### PR DESCRIPTION
Pulling in patch from our old quantum fork.
https://github.com/dreamhost/quantum/commit/fc734945148ccf23dea8629237d9a54f3fa7910c